### PR TITLE
ignore cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ dist/
 __pycache__
 .coverage
 .tox/
+.cache/


### PR DESCRIPTION
This PR adds `.cache` directory to `.gitignore`.
It seems to be created by pytest.