### PR TITLE
Settings frame init

### DIFF
--- a/hyperframe/frame.py
+++ b/hyperframe/frame.py
@@ -277,11 +277,17 @@ class SettingsFrame(Frame):
     SETTINGS_MAX_FRAME_SIZE       = 0x05
     SETTINGS_MAX_HEADER_LIST_SIZE = 0x06
 
-    def __init__(self, stream_id=0):
+    def __init__(self, stream_id=0, settings=None, ack=False):
         super(SettingsFrame, self).__init__(stream_id)
 
+        if settings and ack:
+            raise ValueError("Settings must be empty if ACK flag is set.")
+
         # A dictionary of the setting type byte to the value.
-        self.settings = {}
+        self.settings = settings or {}
+
+        if ack:
+            self.flags.add('ACK')
 
     def serialize_body(self):
         settings = [struct.pack("!HL", setting & 0xFF, value)

--- a/test/test_hyperframe.py
+++ b/test/test_hyperframe.py
@@ -227,6 +227,22 @@ class TestSettingsFrame(object):
         s = f.serialize()
         assert s == self.serialized
 
+    def test_settings_frame_with_settings(self):
+        f = SettingsFrame(settings=self.settings)
+        assert f.settings == self.settings
+
+    def test_settings_frame_without_settings(self):
+        f = SettingsFrame()
+        assert f.settings == {}
+
+    def test_settings_frame_with_ack(self):
+        f = SettingsFrame(ack=True)
+        assert 'ACK' in f.flags
+
+    def test_settings_frame_ack_and_settings(self):
+        with pytest.raises(ValueError):
+            SettingsFrame(settings=self.settings, ack=True)
+
     def test_settings_frame_parses_properly(self):
         f = decode_frame(self.serialized)
 


### PR DESCRIPTION
similar to #7

This PR allows us to pass in settings during SettingsFrame initialization - which makes it a bit less verbose.