### PR TITLE
add flag validation

### DIFF
--- a/hyperframe/flags.py
+++ b/hyperframe/flags.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+"""
+hyperframe/flags
+~~~~~~~~~~~~~~~~
+
+Defines basic Flag and Flags data structures.
+"""
+import collections
+try:
+    from collections.abc import MutableSet
+except ImportError:  # pragma: nocover
+    from collections import MutableSet
+
+
+Flag = collections.namedtuple("Flag", ["name", "bit"])
+
+
+class Flags(MutableSet):
+    """
+    A simple MutableSet implementation that will only accept known flags as elements.
+
+    Will behave like a regular set(), except that a ValueError will be thrown when .add()ing
+    unexpected flags.
+    """
+    def __init__(self, defined_flags):
+        self._valid_flags = set(flag.name for flag in defined_flags)
+        self._flags = set()
+
+    def __contains__(self, x):
+        return self._flags.__contains__(x)
+
+    def __iter__(self):
+        return self._flags.__iter__()
+
+    def __len__(self):
+        return self._flags.__len__()
+
+    def discard(self, value):
+        return self._flags.discard(value)
+
+    def add(self, value):
+        if value not in self._valid_flags:
+            raise ValueError("Unexpected flag: {}".format(value))
+        return self._flags.add(value)

--- a/hyperframe/frame.py
+++ b/hyperframe/frame.py
@@ -9,16 +9,15 @@ socket.
 """
 import collections
 import struct
-try:
-    from collections.abc import MutableSet
-except ImportError:  # pragma: nocover
-    from collections import MutableSet
+
+from .flags import Flag, Flags
 
 # The maximum initial length of a frame. Some frames have shorter maximum lengths.
 FRAME_MAX_LEN = (2 ** 14)
 
 # The maximum allowed length of a frame.
 FRAME_MAX_ALLOWED_LEN = (2 ** 24) - 1
+
 
 class Frame(object):
     """
@@ -111,33 +110,6 @@ class Frame(object):
 
     def parse_body(self, data):
         raise NotImplementedError()
-
-
-Flag = collections.namedtuple("Flag", ["name", "bit"])
-
-
-class Flags(MutableSet):
-
-    def __init__(self, defined_flags):
-        self._valid_flags = set(flag.name for flag in defined_flags)
-        self._flags = set()
-
-    def __contains__(self, x):
-        return self._flags.__contains__(x)
-
-    def __iter__(self):
-        return self._flags.__iter__()
-
-    def __len__(self):
-        return self._flags.__len__()
-
-    def discard(self, value):
-        return self._flags.discard(value)
-
-    def add(self, value):
-        if value not in self._valid_flags:
-            raise ValueError("Unexpected flag: {}".format(value))
-        return self._flags.add(value)
 
 
 class Padding(object):

--- a/hyperframe/frame.py
+++ b/hyperframe/frame.py
@@ -9,6 +9,10 @@ socket.
 """
 import collections
 import struct
+try:
+    from collections.abc import MutableSet
+except ImportError:  # pragma: nocover
+    from collections import MutableSet
 
 # The maximum initial length of a frame. Some frames have shorter maximum lengths.
 FRAME_MAX_LEN = (2 ** 14)
@@ -32,7 +36,7 @@ class Frame(object):
 
     def __init__(self, stream_id, flags=()):
         self.stream_id = stream_id
-        self.flags = set()
+        self.flags = Flags(self.defined_flags)
         self.body_len = 0
 
         for flag in flags:
@@ -109,6 +113,33 @@ class Frame(object):
         raise NotImplementedError()
 
 
+Flag = collections.namedtuple("Flag", ["name", "bit"])
+
+
+class Flags(MutableSet):
+
+    def __init__(self, defined_flags):
+        self._valid_flags = set(flag.name for flag in defined_flags)
+        self._flags = set()
+
+    def __contains__(self, x):
+        return self._flags.__contains__(x)
+
+    def __iter__(self):
+        return self._flags.__iter__()
+
+    def __len__(self):
+        return self._flags.__len__()
+
+    def discard(self, value):
+        return self._flags.discard(value)
+
+    def add(self, value):
+        if value not in self._valid_flags:
+            raise ValueError("Unexpected flag: {}".format(value))
+        return self._flags.add(value)
+
+
 class Padding(object):
     """
     Mixin for frames that contain padding.
@@ -176,8 +207,8 @@ class DataFrame(Padding, Frame):
     to carry HTTP request or response payloads.
     """
     defined_flags = [
-        ('END_STREAM', 0x01),
-        ('PADDED', 0x08),
+        Flag('END_STREAM', 0x01),
+        Flag('PADDED', 0x08),
     ]
 
     type = 0x0
@@ -269,7 +300,7 @@ class SettingsFrame(Frame):
     might set a high initial flow control window, whereas a server might set a
     lower value to conserve resources.
     """
-    defined_flags = [('ACK', 0x01)]
+    defined_flags = [Flag('ACK', 0x01)]
 
     type = 0x04
 
@@ -309,7 +340,10 @@ class PushPromiseFrame(Padding, Frame):
     The PUSH_PROMISE frame is used to notify the peer endpoint in advance of
     streams the sender intends to initiate.
     """
-    defined_flags = [('END_HEADERS', 0x04), ('PADDED', 0x08),]
+    defined_flags = [
+        Flag('END_HEADERS', 0x04),
+        Flag('PADDED', 0x08)
+    ]
 
     type = 0x05
 
@@ -339,7 +373,7 @@ class PingFrame(Frame):
     the sender, as well as determining whether an idle connection is still
     functional. PING frames can be sent from any endpoint.
     """
-    defined_flags = [('ACK', 0x01)]
+    defined_flags = [Flag('ACK', 0x01)]
 
     type = 0x06
 
@@ -446,10 +480,10 @@ class HeadersFrame(Padding, Priority, Frame):
     stream_association = 'has-stream'
 
     defined_flags = [
-        ('END_STREAM', 0x01),
-        ('END_HEADERS', 0x04),
-        ('PADDED', 0x08),
-        ('PRIORITY', 0x20),
+        Flag('END_STREAM', 0x01),
+        Flag('END_HEADERS', 0x04),
+        Flag('PADDED', 0x08),
+        Flag('PRIORITY', 0x20),
     ]
 
     def __init__(self, stream_id, data=b'', **kwargs):
@@ -494,7 +528,7 @@ class ContinuationFrame(Frame):
 
     stream_association = 'has-stream'
 
-    defined_flags = [('END_HEADERS', 0x04),]
+    defined_flags = [Flag('END_HEADERS', 0x04),]
 
     def __init__(self, stream_id, data=b'', **kwargs):
         super(ContinuationFrame, self).__init__(stream_id, **kwargs)

--- a/test/test_flags.py
+++ b/test/test_flags.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+from hyperframe.frame import (
+    Flags, Flag,
+)
+import pytest
+
+
+class TestFlags(object):
+    def test_add(self):
+        flags = Flags([Flag("VALID_FLAG", 0x00)])
+        assert not flags
+
+        flags.add("VALID_FLAG")
+        flags.add("VALID_FLAG")
+        assert "VALID_FLAG" in flags
+        assert list(flags) == ["VALID_FLAG"]
+        assert len(flags) == 1
+
+    def test_remove(self):
+        flags = Flags([Flag("VALID_FLAG", 0x00)])
+        flags.add("VALID_FLAG")
+
+        flags.discard("VALID_FLAG")
+        assert "VALID_FLAG" not in flags
+        assert list(flags) == []
+        assert len(flags) == 0
+
+        # discarding elements not in the set should not throw an exception
+        flags.discard("END_STREAM")
+
+    def test_validation(self):
+        flags = Flags([Flag("VALID_FLAG", 0x00)])
+        flags.add("VALID_FLAG")
+        with pytest.raises(ValueError):
+            flags.add("INVALID_FLAG")

--- a/test/test_frames.py
+++ b/test/test_frames.py
@@ -45,24 +45,6 @@ class TestGeneralFrameBehaviour(object):
         assert repr(f) == "Frame(Stream: 0; Flags: None): {}...".format("A"*100)
 
 
-class TestFlags(object):
-    def test_general_behaviour(self):
-        f = DataFrame(1)
-        assert not f.flags
-
-        f.flags.add("END_STREAM")
-        assert "END_STREAM" in f.flags
-        assert list(f.flags) == ["END_STREAM"]
-        assert len(f.flags) == 1
-
-        f.flags.discard("END_STREAM")
-        assert "END_STREAM" not in f.flags
-        f.flags.discard("END_STREAM")
-
-        with pytest.raises(ValueError):
-            f.flags.add("END_HEADERS")
-
-
 class TestDataFrame(object):
     payload = b'\x00\x00\x08\x00\x01\x00\x00\x00\x01testdata'
     payload_with_padding = b'\x00\x00\x13\x00\x09\x00\x00\x00\x01\x0Atestdata' + b'\0' * 10

--- a/test/test_hyperframe.py
+++ b/test/test_hyperframe.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 from hyperframe.frame import (
-    Frame, DataFrame, PriorityFrame, RstStreamFrame, SettingsFrame,
+    Frame, Flags, DataFrame, PriorityFrame, RstStreamFrame, SettingsFrame,
     PushPromiseFrame, PingFrame, GoAwayFrame, WindowUpdateFrame, HeadersFrame,
     ContinuationFrame, AltSvcFrame, Origin, BlockedFrame,
 )
@@ -19,7 +19,7 @@ class TestGeneralFrameBehaviour(object):
         f = Frame(stream_id=0)
         flags = f.parse_flags(0xFF)
         assert not flags
-        assert isinstance(flags, set)
+        assert isinstance(flags, Flags)
 
     def test_base_frame_cant_serialize(self):
         f = Frame(stream_id=0)
@@ -43,6 +43,25 @@ class TestGeneralFrameBehaviour(object):
 
         monkeypatch.setattr(Frame, "serialize_body", lambda _: "A"*105)
         assert repr(f) == "Frame(Stream: 0; Flags: None): {}...".format("A"*100)
+
+
+class TestFlags(object):
+    def test_general_behaviour(self):
+        f = DataFrame(1)
+        assert not f.flags
+
+        f.flags.add("END_STREAM")
+        assert "END_STREAM" in f.flags
+        assert list(f.flags) == ["END_STREAM"]
+        assert len(f.flags) == 1
+
+        f.flags.discard("END_STREAM")
+        assert "END_STREAM" not in f.flags
+        f.flags.discard("END_STREAM")
+
+        with pytest.raises(ValueError):
+            f.flags.add("END_HEADERS")
+
 
 class TestDataFrame(object):
     payload = b'\x00\x00\x08\x00\x01\x00\x00\x00\x01testdata'
@@ -142,7 +161,7 @@ class TestPriorityFrame(object):
         f = PriorityFrame(1)
         flags = f.parse_flags(0xFF)
         assert flags == set()
-        assert isinstance(flags, set)
+        assert isinstance(flags, Flags)
 
     def test_priority_frame_with_all_data_serializes_properly(self):
         f = PriorityFrame(1)
@@ -171,7 +190,7 @@ class TestRstStreamFrame(object):
         f = RstStreamFrame(1)
         flags = f.parse_flags(0xFF)
         assert not flags
-        assert isinstance(flags, set)
+        assert isinstance(flags, Flags)
 
     def test_rst_stream_frame_serializes_properly(self):
         f = RstStreamFrame(1)
@@ -341,7 +360,7 @@ class TestGoAwayFrame(object):
         flags = f.parse_flags(0xFF)
 
         assert not flags
-        assert isinstance(flags, set)
+        assert isinstance(flags, Flags)
 
     def test_goaway_serializes_properly(self):
         f = GoAwayFrame()
@@ -381,7 +400,7 @@ class TestWindowUpdateFrame(object):
         flags = f.parse_flags(0xFF)
 
         assert not flags
-        assert isinstance(flags, set)
+        assert isinstance(flags, Flags)
 
     def test_window_update_serializes_properly(self):
         f = WindowUpdateFrame(0)
@@ -565,7 +584,7 @@ class TestBlockedFrame(object):
         flags = f.parse_flags(0xFF)
 
         assert not flags
-        assert isinstance(flags, set)
+        assert isinstance(flags, Flags)
 
     def test_blocked_serializes_properly(self):
         f = BlockedFrame(2)


### PR DESCRIPTION
We had slightly different flag names in our old mitmproxy code (e.g. https://github.com/mitmproxy/netlib/commit/d7ada2f6b6a3b4dc2525c12c2ae24bf3d5e043b4), which went unnoticed because hyperframe just swallowed invalid flags. I personally think it would be nice to have some validation here. If you want to keep things simpler, that'd be okay as well as we found our offenders now. :wink: 

Cheers,
Max

