### PR TITLE
Add stricter frame parsing

### DIFF
--- a/hyperframe/frame.py
+++ b/hyperframe/frame.py
@@ -62,6 +62,9 @@ class Frame(object):
         flags = fields[3]
         stream_id = fields[4]
 
+        if type not in FRAMES:
+            raise ValueError("Unknown frame type %d" % type)
+
         frame = FRAMES[type](stream_id)
         frame.parse_flags(flags)
         return (frame, length)

--- a/test/test_hyperframe.py
+++ b/test/test_hyperframe.py
@@ -32,6 +32,10 @@ class TestGeneralFrameBehaviour(object):
         with pytest.raises(NotImplementedError):
             f.parse_body(data)
 
+    def test_parse_frame_header_unknown_type(self):
+        with pytest.raises(ValueError):
+            Frame.parse_frame_header(b'\x00\x00\x00\xFF\x00\x00\x00\x00\x01')
+
     def test_repr(self, monkeypatch):
         f = Frame(stream_id=0)
         monkeypatch.setattr(Frame, "serialize_body", lambda _: "body")


### PR DESCRIPTION
`Frame.parse_frame_header` should throw a ValueError if the frame type is unknown, throwing a KeyError feels weird.