### PR TITLE
Allow attributes to be set via constructors

### DIFF
--- a/test/test_hyperframe.py
+++ b/test/test_hyperframe.py
@@ -240,12 +240,12 @@ class TestSettingsFrame(object):
         assert f.settings == {}
 
     def test_settings_frame_with_ack(self):
-        f = SettingsFrame(ack=True)
+        f = SettingsFrame(flags=('ACK',))
         assert 'ACK' in f.flags
 
     def test_settings_frame_ack_and_settings(self):
         with pytest.raises(ValueError):
-            SettingsFrame(settings=self.settings, ack=True)
+            SettingsFrame(settings=self.settings, flags=('ACK',))
 
     def test_settings_frame_parses_properly(self):
         f = decode_frame(self.serialized)


### PR DESCRIPTION
This PR supersedes #7 and allows setting all frame attributes via constructors. The only unusual thing in this PR might be that mixin arguments (and `flags`) are provided as keyword arguments only. This has been done as the combination of mixins and positional arguments tends to be quite confusing.

An alternative would be to repeat all arguments in each constructor, but I found this to be quite verbose.