### PR TITLE
Pin test dependency versions.

### DIFF
--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,3 +1,3 @@
-pytest
-pytest-xdist
-pytest-cov
+pytest==2.7.3
+pytest-cov==2.1.0
+pytest-xdist==1.13.1


### PR DESCRIPTION
Python 3.5 builds were failing for no good reason: turned out to be test dependencies.