### PR TITLE
Add new UnknownFrameError

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,15 @@
 Release History
 ===============
 
+dev
+---
+
+**API Changes**
+
+- When an unknown frame is encountered, ``parse_frame_header`` now throws a
+  ``ValueError`` subclass: ``UnknownFrameError``. This subclass contains the
+  frame type and the length of the frame body.
+
 2.1.0 (2015-10-06)
 ------------------
 

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -64,3 +64,9 @@ you need is not present!
    :members:
 
 .. autodata:: hyperframe.frame.FRAMES
+
+Exceptions
+----------
+
+.. autoclass:: hyperframe.exceptions.UnknownFrameError
+   :members:

--- a/hyperframe/exceptions.py
+++ b/hyperframe/exceptions.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+"""
+hyperframe/exceptions
+~~~~~~~~~~~~~~~~~~~~~
+
+Defines the exceptions that can be thrown by hyperframe.
+"""
+
+
+class UnknownFrameError(ValueError):
+    """
+    An frame of unknown type was received.
+    """
+    def __init__(self, frame_type, length):
+        #: The type byte of the unknown frame that was received.
+        self.frame_type = frame_type
+
+        #: The length of the data portion of the unknown frame.
+        self.length = length
+
+    def __str__(self):
+        return (
+            "UnknownFrameError: Unknown frame type 0x%X received, "
+            "length %d bytes" % (self.frame_type, self.length)
+        )

--- a/hyperframe/frame.py
+++ b/hyperframe/frame.py
@@ -10,6 +10,7 @@ socket.
 import collections
 import struct
 
+from .exceptions import UnknownFrameError
 from .flags import Flag, Flags
 
 # The maximum initial length of a frame. Some frames have shorter maximum lengths.
@@ -68,6 +69,9 @@ class Frame(object):
         Frame object and the length that needs to be read from the socket.
 
         This populates the flags field, and determines how long the body is.
+
+        :raises hyperframe.exceptions.UnknownFrameError: If a frame of unknown
+            type is received.
         """
         fields = struct.unpack("!HBBBL", header)
         # First 24 bits are frame length.
@@ -77,7 +81,7 @@ class Frame(object):
         stream_id = fields[4]
 
         if type not in FRAMES:
-            raise ValueError("Unknown frame type %d" % type)
+            raise UnknownFrameError(type, length)
 
         frame = FRAMES[type](stream_id)
         frame.parse_flags(flags)

--- a/test/test_frames.py
+++ b/test/test_frames.py
@@ -4,6 +4,7 @@ from hyperframe.frame import (
     PushPromiseFrame, PingFrame, GoAwayFrame, WindowUpdateFrame, HeadersFrame,
     ContinuationFrame, AltSvcFrame, Origin, BlockedFrame,
 )
+from hyperframe.exceptions import UnknownFrameError
 import pytest
 
 
@@ -33,8 +34,16 @@ class TestGeneralFrameBehaviour(object):
             f.parse_body(data)
 
     def test_parse_frame_header_unknown_type(self):
-        with pytest.raises(ValueError):
-            Frame.parse_frame_header(b'\x00\x00\x00\xFF\x00\x00\x00\x00\x01')
+        with pytest.raises(UnknownFrameError) as excinfo:
+            Frame.parse_frame_header(b'\x00\x00\x59\xFF\x00\x00\x00\x00\x01')
+
+        exception = excinfo.value
+        assert exception.frame_type == 0xFF
+        assert exception.length == 0x59
+        assert str(exception) == (
+            "UnknownFrameError: Unknown frame type 0xFF received, "
+            "length 89 bytes"
+        )
 
     def test_repr(self, monkeypatch):
         f = Frame(stream_id=0)


### PR DESCRIPTION
This allows users to introspect the unknown frame and potentially to skip it for frame parsing.