### PR TITLE
Don't raise InvalidPaddingError on unpadded 0 length frames

### DIFF
--- a/hyperframe/frame.py
+++ b/hyperframe/frame.py
@@ -232,7 +232,7 @@ class DataFrame(Padding, Frame):
         self.data = data[padding_data_length:len(data)-self.total_padding].tobytes()
         self.body_len = len(data)
 
-        if self.total_padding >= self.body_len:
+        if self.total_padding and self.total_padding >= self.body_len:
             raise InvalidPaddingError("Padding is too long.")
 
     @property
@@ -396,7 +396,7 @@ class PushPromiseFrame(Padding, Frame):
         self.data = data[padding_data_length + 4:].tobytes()
         self.body_len = len(data)
 
-        if self.total_padding >= self.body_len:
+        if self.total_padding and self.total_padding >= self.body_len:
             raise InvalidPaddingError("Padding is too long.")
 
 
@@ -570,7 +570,7 @@ class HeadersFrame(Padding, Priority, Frame):
         self.body_len = len(data)
         self.data = data[priority_data_length:len(data)-self.total_padding].tobytes()
 
-        if self.total_padding >= self.body_len:
+        if self.total_padding and self.total_padding >= self.body_len:
             raise InvalidPaddingError("Padding is too long.")
 
 

--- a/test/test_frames.py
+++ b/test/test_frames.py
@@ -154,6 +154,15 @@ class TestDataFrame(object):
         with pytest.raises(InvalidPaddingError):
             decode_frame(data)
 
+    def test_data_frame_with_no_length_parses(self):
+        # Fixes issue with empty data frames raising InvalidPaddingError.
+        f = DataFrame(1)
+        f.data = b''
+        data = f.serialize()
+
+        new_frame = decode_frame(data)
+        assert new_frame.data == b''
+
 
 class TestPriorityFrame(object):
     payload = b'\x00\x00\x05\x02\x00\x00\x00\x00\x01\x80\x00\x00\x04\x40'
@@ -323,6 +332,15 @@ class TestPushPromiseFrame(object):
 
         with pytest.raises(InvalidPaddingError):
             decode_frame(data)
+
+    def test_push_promise_frame_with_no_length_parses(self):
+        # Fixes issue with empty data frames raising InvalidPaddingError.
+        f = PushPromiseFrame(1)
+        f.data = b''
+        data = f.serialize()
+
+        new_frame = decode_frame(data)
+        assert new_frame.data == b''
 
 
 class TestPingFrame(object):
@@ -505,6 +523,15 @@ class TestHeadersFrame(object):
 
         with pytest.raises(InvalidPaddingError):
             decode_frame(data)
+
+    def test_headers_frame_with_no_length_parses(self):
+        # Fixes issue with empty data frames raising InvalidPaddingError.
+        f = HeadersFrame(1)
+        f.data = b''
+        data = f.serialize()
+
+        new_frame = decode_frame(data)
+        assert new_frame.data == b''
 
 
 class TestContinuationFrame(object):


### PR DESCRIPTION
Resolves a bug in hyperframe 3.0.0 where zero-length data frames with no padding raise InvalidPaddingError. This error should generally be impossible to raise in a situation where there is no padding.