### PR TITLE
fix default values due to incompatible conversions

### DIFF
--- a/hyperframe/frame.py
+++ b/hyperframe/frame.py
@@ -170,7 +170,7 @@ class Priority(object):
     Mixin for frames that contain priority data. Defines extra fields that can
     be used and set by frames that contain priority data.
     """
-    def __init__(self, stream_id, depends_on=None, stream_weight=None, exclusive=None, **kwargs):
+    def __init__(self, stream_id, depends_on=0x0, stream_weight=0x0, exclusive=False, **kwargs):
         super(Priority, self).__init__(stream_id, **kwargs)
 
         #: The stream ID of the stream on which this stream depends.

--- a/test/test_frames.py
+++ b/test/test_frames.py
@@ -173,6 +173,11 @@ class TestPriorityFrame(object):
         assert flags == set()
         assert isinstance(flags, Flags)
 
+    def test_priority_frame_default_serializes_properly(self):
+        f = PriorityFrame(1)
+
+        assert f.serialize() == b'\x00\x00\x05\x02\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00'
+
     def test_priority_frame_with_all_data_serializes_properly(self):
         f = PriorityFrame(1)
         f.depends_on = 0x04


### PR DESCRIPTION
`None` does not play well with `int(None)` and `None | 0x0`.
This might induce a change in hyper-h2.