### PR TITLE
Reject short PING frames.

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,13 @@
 Release History
 ===============
 
+dev
+---
+
+**Bugfixes**
+
+- Correctly error when receiving Ping frames that have insufficient data.
+
 3.1.0 (2016-01-13)
 ------------------
 

--- a/hyperframe/frame.py
+++ b/hyperframe/frame.py
@@ -459,7 +459,7 @@ class PingFrame(Frame):
         return data
 
     def parse_body(self, data):
-        if len(data) > 8:
+        if len(data) != 8:
             raise ValueError()
 
         self.opaque_data = data.tobytes()

--- a/test/test_frames.py
+++ b/test/test_frames.py
@@ -417,6 +417,11 @@ class TestPingFrame(object):
         with pytest.raises(ValueError):
             f.parse_body(b'\x01\x02\x03\x04\x05\x06\x07\x08\x09')
 
+    def test_ping_frame_has_no_less_than_body_length_8(self):
+        f = PingFrame()
+        with pytest.raises(ValueError):
+            f.parse_body(b'\x01\x02\x03\x04\x05\x06\x07')
+
 
 class TestGoAwayFrame(object):
     def test_go_away_has_no_flags(self):


### PR DESCRIPTION
Ping frames must have exactly 8 bytes of data.