### PR TITLE
rename and unify setting variable names

### DIFF
--- a/hyperframe/frame.py
+++ b/hyperframe/frame.py
@@ -343,17 +343,26 @@ class SettingsFrame(Frame):
     # We need to define the known settings, they may as well be class
     # attributes.
     #: The byte that signals the SETTINGS_HEADER_TABLE_SIZE setting.
-    HEADER_TABLE_SIZE             = 0x01
+    HEADER_TABLE_SIZE      = 0x01
     #: The byte that signals the SETTINGS_ENABLE_PUSH setting.
-    ENABLE_PUSH                   = 0x02
+    ENABLE_PUSH            = 0x02
     #: The byte that signals the SETTINGS_MAX_CONCURRENT_STREAMS setting.
-    MAX_CONCURRENT_STREAMS        = 0x03
+    MAX_CONCURRENT_STREAMS = 0x03
     #: The byte that signals the SETTINGS_INITIAL_WINDOW_SIZE setting.
-    INITIAL_WINDOW_SIZE           = 0x04
+    INITIAL_WINDOW_SIZE    = 0x04
     #: The byte that signals the SETTINGS_MAX_FRAME_SIZE setting.
-    SETTINGS_MAX_FRAME_SIZE       = 0x05
+    MAX_FRAME_SIZE         = 0x05
     #: The byte that signals the SETTINGS_MAX_HEADER_LIST_SIZE setting.
-    SETTINGS_MAX_HEADER_LIST_SIZE = 0x06
+    MAX_HEADER_LIST_SIZE   = 0x06
+
+    #: The byte that signals the SETTINGS_MAX_FRAME_SIZE setting.
+    #: .. deprecated:: 3.2.0
+    #:    Use :data:`MAX_FRAME_SIZE <SettingsFrame.MAX_FRAME_SIZE>` instead.
+    SETTINGS_MAX_FRAME_SIZE = MAX_FRAME_SIZE
+    #: The byte that signals the SETTINGS_MAX_HEADER_LIST_SIZE setting.
+    #: .. deprecated:: 3.2.0
+    #     Use :data:`MAX_HEADER_LIST_SIZE <SettingsFrame.MAX_HEADER_LIST_SIZE>` instead.
+    SETTINGS_MAX_HEADER_LIST_SIZE = MAX_HEADER_LIST_SIZE
 
     def __init__(self, stream_id=0, settings=None, **kwargs):
         super(SettingsFrame, self).__init__(stream_id, **kwargs)

--- a/test/test_frames.py
+++ b/test/test_frames.py
@@ -255,8 +255,8 @@ class TestSettingsFrame(object):
         b'\x00\x02\x00\x00\x00\x00'             +  # ENABLE_PUSH
         b'\x00\x03\x00\x00\x00\x64'             +  # MAX_CONCURRENT_STREAMS
         b'\x00\x04\x00\x00\xFF\xFF'             +  # INITIAL_WINDOW_SIZE
-        b'\x00\x05\x00\x00\x40\x00'             +  # SETTINGS_MAX_FRAME_SIZE
-        b'\x00\x06\x00\x00\xFF\xFF'                # SETTINGS_MAX_HEADER_LIST_SIZE
+        b'\x00\x05\x00\x00\x40\x00'             +  # MAX_FRAME_SIZE
+        b'\x00\x06\x00\x00\xFF\xFF'                # MAX_HEADER_LIST_SIZE
     )
 
     settings = {
@@ -264,8 +264,8 @@ class TestSettingsFrame(object):
         SettingsFrame.ENABLE_PUSH: 0,
         SettingsFrame.MAX_CONCURRENT_STREAMS: 100,
         SettingsFrame.INITIAL_WINDOW_SIZE: 65535,
-        SettingsFrame.SETTINGS_MAX_FRAME_SIZE: 16384,
-        SettingsFrame.SETTINGS_MAX_HEADER_LIST_SIZE: 65535,
+        SettingsFrame.MAX_FRAME_SIZE: 16384,
+        SettingsFrame.MAX_HEADER_LIST_SIZE: 65535,
     }
 
     def test_settings_frame_has_only_one_flag(self):


### PR DESCRIPTION
fixes #29 

Not sure if the doc-strings actually work - any ideas to clearly mark the deprecation?
I also played with the idea of printing a warning to stderr or so, but that is a bit too much I think.