### PR TITLE
Fix AltSvcFrame `stream_association`

### DIFF
--- a/hyperframe/frame.py
+++ b/hyperframe/frame.py
@@ -691,7 +691,7 @@ class AltSvcFrame(Frame):
     """
     type = 0xA
 
-    stream_association = 'both'
+    stream_association = 'either'
 
     def __init__(self, stream_id, origin=b'', field=b'', **kwargs):
         super(AltSvcFrame, self).__init__(stream_id, **kwargs)


### PR DESCRIPTION
As per [Twitter](https://twitter.com/lukasaoz/status/765820112893009920), small PR to fix the `AltSvcFrame` `stream_association` to be `either`, instead of the incorrect `both`. The logic works correctly with either value, regardless.