### PR TITLE
Optimization of Frame parsing/serialization.

### DIFF
--- a/hyperframe/frame.py
+++ b/hyperframe/frame.py
@@ -66,9 +66,11 @@ class Frame(object):
         for flag in flags:
             self.flags.add(flag)
 
-        if not self.stream_id and self.stream_association == _STREAM_ASSOC_HAS_STREAM:
+        if (not self.stream_id and
+           self.stream_association == _STREAM_ASSOC_HAS_STREAM):
             raise ValueError('Stream ID must be non-zero')
-        if self.stream_id and self.stream_association == _STREAM_ASSOC_NO_STREAM:
+        if (self.stream_id and
+           self.stream_association == _STREAM_ASSOC_NO_STREAM):
             raise ValueError('Stream ID must be zero')
 
     def __repr__(self):

--- a/hyperframe/frame.py
+++ b/hyperframe/frame.py
@@ -9,7 +9,6 @@ socket.
 """
 import struct
 import binascii
-import sys
 
 from .exceptions import (
     UnknownFrameError, InvalidPaddingError, InvalidFrameError
@@ -37,8 +36,6 @@ _STRUCT_LB = struct.Struct("!LB")
 _STRUCT_L = struct.Struct("!L")
 _STRUCT_H = struct.Struct("!H")
 _STRUCT_B = struct.Struct("!B")
-
-_PY3 = sys.version_info > (3, 0, 0)
 
 
 class Frame(object):

--- a/hyperframe/frame.py
+++ b/hyperframe/frame.py
@@ -395,7 +395,7 @@ class SettingsFrame(Frame):
                          for setting, value in self.settings.items()])
 
     def parse_body(self, data):
-        number_of_settings = 0
+        body_len = 0
         for i in range(0, len(data), 6):
             try:
                 name, value = _STRUCT_HL.unpack(data[i:i+6])
@@ -403,9 +403,9 @@ class SettingsFrame(Frame):
                 raise InvalidFrameError("Invalid SETTINGS body")
 
             self.settings[name] = value
-            number_of_settings += 1
+            body_len += 6
 
-        self.body_len = number_of_settings * 6
+        self.body_len = body_len
 
 
 class PushPromiseFrame(Padding, Frame):

--- a/hyperframe/frame.py
+++ b/hyperframe/frame.py
@@ -9,6 +9,7 @@ socket.
 """
 import struct
 import binascii
+import sys
 
 from .exceptions import (
     UnknownFrameError, InvalidPaddingError, InvalidFrameError
@@ -22,6 +23,22 @@ FRAME_MAX_LEN = (2 ** 14)
 
 # The maximum allowed length of a frame.
 FRAME_MAX_ALLOWED_LEN = (2 ** 24) - 1
+
+# Stream association enumerations.
+_STREAM_ASSOC_HAS_STREAM = "has-stream"
+_STREAM_ASSOC_NO_STREAM = "no-stream"
+_STREAM_ASSOC_EITHER = "either"
+
+# Structs for packing and unpacking
+_STRUCT_HBBBL = struct.Struct("!HBBBL")
+_STRUCT_LL = struct.Struct("!LL")
+_STRUCT_HL = struct.Struct("!HL")
+_STRUCT_LB = struct.Struct("!LB")
+_STRUCT_L = struct.Struct("!L")
+_STRUCT_H = struct.Struct("!H")
+_STRUCT_B = struct.Struct("!B")
+
+_PY3 = sys.version_info > (3, 0, 0)
 
 
 class Frame(object):
@@ -52,9 +69,9 @@ class Frame(object):
         for flag in flags:
             self.flags.add(flag)
 
-        if self.stream_association == 'has-stream' and not self.stream_id:
+        if not self.stream_id and self.stream_association == _STREAM_ASSOC_HAS_STREAM:
             raise ValueError('Stream ID must be non-zero')
-        if self.stream_association == 'no-stream' and self.stream_id:
+        if self.stream_id and self.stream_association == _STREAM_ASSOC_NO_STREAM:
             raise ValueError('Stream ID must be zero')
 
     def __repr__(self):
@@ -83,7 +100,7 @@ class Frame(object):
             type is received.
         """
         try:
-            fields = struct.unpack("!HBBBL", header)
+            fields = _STRUCT_HBBBL.unpack(header)
         except struct.error:
             raise InvalidFrameError("Invalid frame header")
 
@@ -123,10 +140,9 @@ class Frame(object):
             if flag in self.flags:
                 flags |= flag_bit
 
-        header = struct.pack(
-            "!HBBBL",
-            (self.body_len & 0xFFFF00) >> 8,  # Length spread over top 24 bits
-            self.body_len & 0x0000FF,
+        header = _STRUCT_HBBBL.pack(
+            (self.body_len >> 8) & 0xFFFF,  # Length spread over top 24 bits
+            self.body_len & 0xFF,
             self.type,
             flags,
             self.stream_id & 0x7FFFFFFF  # Stream ID is 32 bits.
@@ -164,7 +180,7 @@ class Padding(object):
 
     def serialize_padding_data(self):
         if 'PADDED' in self.flags:
-            return struct.pack('!B', self.pad_length)
+            return _STRUCT_B.pack(self.pad_length)
         return b''
 
     def parse_padding_data(self, data):
@@ -204,24 +220,19 @@ class Priority(object):
         self.exclusive = exclusive
 
     def serialize_priority_data(self):
-        return struct.pack(
-            "!LB",
-            self.depends_on | (int(self.exclusive) << 31),
+        return _STRUCT_LB.pack(
+            self.depends_on + (0x80000000 if self.exclusive else 0),
             self.stream_weight
         )
 
     def parse_priority_data(self, data):
-        MASK = 0x80000000
-
         try:
-            self.depends_on, self.stream_weight = struct.unpack(
-                "!LB", data[:5]
-            )
+            self.depends_on, self.stream_weight = _STRUCT_LB.unpack(data[:5])
         except struct.error:
             raise InvalidFrameError("Invalid Priority data")
 
-        self.exclusive = bool(self.depends_on & MASK)
-        self.depends_on &= ~MASK
+        self.exclusive = True if self.depends_on >> 31 else False
+        self.depends_on &= 0x7FFFFFFF
         return 5
 
 
@@ -240,7 +251,7 @@ class DataFrame(Padding, Frame):
     #: The type byte for data frames.
     type = 0x0
 
-    stream_association = 'has-stream'
+    stream_association = _STREAM_ASSOC_HAS_STREAM
 
     def __init__(self, stream_id, data=b'', **kwargs):
         super(DataFrame, self).__init__(stream_id, **kwargs)
@@ -285,7 +296,7 @@ class PriorityFrame(Priority, Frame):
     #: The type byte defined for PRIORITY frames.
     type = 0x02
 
-    stream_association = 'has-stream'
+    stream_association = _STREAM_ASSOC_HAS_STREAM
 
     def serialize_body(self):
         return self.serialize_priority_data()
@@ -310,7 +321,7 @@ class RstStreamFrame(Frame):
     #: The type byte defined for RST_STREAM frames.
     type = 0x03
 
-    stream_association = 'has-stream'
+    stream_association = _STREAM_ASSOC_HAS_STREAM
 
     def __init__(self, stream_id, error_code=0, **kwargs):
         super(RstStreamFrame, self).__init__(stream_id, **kwargs)
@@ -319,7 +330,7 @@ class RstStreamFrame(Frame):
         self.error_code = error_code
 
     def serialize_body(self):
-        return struct.pack("!L", self.error_code)
+        return _STRUCT_L.pack(self.error_code)
 
     def parse_body(self, data):
         if len(data) != 4:
@@ -329,11 +340,11 @@ class RstStreamFrame(Frame):
             )
 
         try:
-            self.error_code = struct.unpack("!L", data)[0]
+            self.error_code = _STRUCT_L.unpack(data)[0]
         except struct.error:  # pragma: no cover
             raise InvalidFrameError("Invalid RST_STREAM body")
 
-        self.body_len = len(data)
+        self.body_len = 4
 
 
 class SettingsFrame(Frame):
@@ -354,7 +365,7 @@ class SettingsFrame(Frame):
     #: The type byte defined for SETTINGS frames.
     type = 0x04
 
-    stream_association = 'no-stream'
+    stream_association = _STREAM_ASSOC_NO_STREAM
 
     # We need to define the known settings, they may as well be class
     # attributes.
@@ -381,20 +392,21 @@ class SettingsFrame(Frame):
         self.settings = settings or {}
 
     def serialize_body(self):
-        settings = [struct.pack("!HL", setting & 0xFF, value)
-                    for setting, value in self.settings.items()]
-        return b''.join(settings)
+        return b''.join([_STRUCT_HL.pack(setting & 0xFF, value)
+                         for setting, value in self.settings.items()])
 
     def parse_body(self, data):
+        number_of_settings = 0
         for i in range(0, len(data), 6):
             try:
-                name, value = struct.unpack("!HL", data[i:i+6])
+                name, value = _STRUCT_HL.unpack(data[i:i+6])
             except struct.error:
                 raise InvalidFrameError("Invalid SETTINGS body")
 
             self.settings[name] = value
+            number_of_settings += 1
 
-        self.body_len = len(data)
+        self.body_len = number_of_settings * 6
 
 
 class PushPromiseFrame(Padding, Frame):
@@ -411,7 +423,7 @@ class PushPromiseFrame(Padding, Frame):
     #: The type byte defined for PUSH_PROMISE frames.
     type = 0x05
 
-    stream_association = 'has-stream'
+    stream_association = _STREAM_ASSOC_HAS_STREAM
 
     def __init__(self, stream_id, promised_stream_id=0, data=b'', **kwargs):
         super(PushPromiseFrame, self).__init__(stream_id, **kwargs)
@@ -426,15 +438,15 @@ class PushPromiseFrame(Padding, Frame):
     def serialize_body(self):
         padding_data = self.serialize_padding_data()
         padding = b'\0' * self.total_padding
-        data = struct.pack("!L", self.promised_stream_id)
+        data = _STRUCT_L.pack(self.promised_stream_id)
         return b''.join([padding_data, data, self.data, padding])
 
     def parse_body(self, data):
         padding_data_length = self.parse_padding_data(data)
 
         try:
-            self.promised_stream_id = struct.unpack(
-                "!L", data[padding_data_length:padding_data_length + 4]
+            self.promised_stream_id = _STRUCT_L.unpack(
+                data[padding_data_length:padding_data_length + 4]
             )[0]
         except struct.error:
             raise InvalidFrameError("Invalid PUSH_PROMISE body")
@@ -458,7 +470,7 @@ class PingFrame(Frame):
     #: The type byte defined for PING frames.
     type = 0x06
 
-    stream_association = 'no-stream'
+    stream_association = _STREAM_ASSOC_NO_STREAM
 
     def __init__(self, stream_id=0, opaque_data=b'', **kwargs):
         super(PingFrame, self).__init__(stream_id, **kwargs)
@@ -484,7 +496,7 @@ class PingFrame(Frame):
             )
 
         self.opaque_data = data.tobytes()
-        self.body_len = len(data)
+        self.body_len = 8
 
 
 class GoAwayFrame(Frame):
@@ -500,7 +512,7 @@ class GoAwayFrame(Frame):
     #: The type byte defined for GOAWAY frames.
     type = 0x07
 
-    stream_association = 'no-stream'
+    stream_association = _STREAM_ASSOC_NO_STREAM
 
     def __init__(self,
                  stream_id=0,
@@ -520,8 +532,7 @@ class GoAwayFrame(Frame):
         self.additional_data = additional_data
 
     def serialize_body(self):
-        data = struct.pack(
-            "!LL",
+        data = _STRUCT_LL.pack(
             self.last_stream_id & 0x7FFFFFFF,
             self.error_code
         )
@@ -531,8 +542,8 @@ class GoAwayFrame(Frame):
 
     def parse_body(self, data):
         try:
-            self.last_stream_id, self.error_code = struct.unpack(
-                "!LL", data[:8]
+            self.last_stream_id, self.error_code = _STRUCT_LL.unpack(
+                data[:8]
             )
         except struct.error:
             raise InvalidFrameError("Invalid GOAWAY body.")
@@ -562,7 +573,7 @@ class WindowUpdateFrame(Frame):
     #: The type byte defined for WINDOW_UPDATE frames.
     type = 0x08
 
-    stream_association = 'either'
+    stream_association = _STREAM_ASSOC_EITHER
 
     def __init__(self, stream_id, window_increment=0, **kwargs):
         super(WindowUpdateFrame, self).__init__(stream_id, **kwargs)
@@ -571,15 +582,15 @@ class WindowUpdateFrame(Frame):
         self.window_increment = window_increment
 
     def serialize_body(self):
-        return struct.pack("!L", self.window_increment & 0x7FFFFFFF)
+        return _STRUCT_L.pack(self.window_increment & 0x7FFFFFFF)
 
     def parse_body(self, data):
         try:
-            self.window_increment = struct.unpack("!L", data)[0]
+            self.window_increment = _STRUCT_L.unpack(data)[0]
         except struct.error:
             raise InvalidFrameError("Invalid WINDOW_UPDATE body")
 
-        self.body_len = len(data)
+        self.body_len = 4
 
 
 class HeadersFrame(Padding, Priority, Frame):
@@ -605,7 +616,7 @@ class HeadersFrame(Padding, Priority, Frame):
     #: The type byte defined for HEADERS frames.
     type = 0x01
 
-    stream_association = 'has-stream'
+    stream_association = _STREAM_ASSOC_HAS_STREAM
 
     def __init__(self, stream_id, data=b'', **kwargs):
         super(HeadersFrame, self).__init__(stream_id, **kwargs)
@@ -658,7 +669,7 @@ class ContinuationFrame(Frame):
     #: The type byte defined for CONTINUATION frames.
     type = 0x09
 
-    stream_association = 'has-stream'
+    stream_association = _STREAM_ASSOC_HAS_STREAM
 
     def __init__(self, stream_id, data=b'', **kwargs):
         super(ContinuationFrame, self).__init__(stream_id, **kwargs)
@@ -691,7 +702,7 @@ class AltSvcFrame(Frame):
     """
     type = 0xA
 
-    stream_association = 'either'
+    stream_association = _STREAM_ASSOC_EITHER
 
     def __init__(self, stream_id, origin=b'', field=b'', **kwargs):
         super(AltSvcFrame, self).__init__(stream_id, **kwargs)
@@ -704,12 +715,12 @@ class AltSvcFrame(Frame):
         self.field = field
 
     def serialize_body(self):
-        origin_len = struct.pack("!H", len(self.origin))
+        origin_len = _STRUCT_H.pack(len(self.origin))
         return b''.join([origin_len, self.origin, self.field])
 
     def parse_body(self, data):
         try:
-            origin_len = struct.unpack("!H", data[0:2])[0]
+            origin_len = _STRUCT_H.unpack(data[0:2])[0]
             self.origin = data[2:2+origin_len].tobytes()
 
             if len(self.origin) != origin_len:

--- a/hyperframe/frame.py
+++ b/hyperframe/frame.py
@@ -29,13 +29,13 @@ _STREAM_ASSOC_NO_STREAM = "no-stream"
 _STREAM_ASSOC_EITHER = "either"
 
 # Structs for packing and unpacking
-_STRUCT_HBBBL = struct.Struct("!HBBBL")
-_STRUCT_LL = struct.Struct("!LL")
-_STRUCT_HL = struct.Struct("!HL")
-_STRUCT_LB = struct.Struct("!LB")
-_STRUCT_L = struct.Struct("!L")
-_STRUCT_H = struct.Struct("!H")
-_STRUCT_B = struct.Struct("!B")
+_STRUCT_HBBBL = struct.Struct(">HBBBL")
+_STRUCT_LL = struct.Struct(">LL")
+_STRUCT_HL = struct.Struct(">HL")
+_STRUCT_LB = struct.Struct(">LB")
+_STRUCT_L = struct.Struct(">L")
+_STRUCT_H = struct.Struct(">H")
+_STRUCT_B = struct.Struct(">B")
 
 
 class Frame(object):


### PR DESCRIPTION
Hello, I am here to provide some ideas of potential optimizations to Frame parsing and serialization at the suggestion of @Lukasa .  All of the following optimizations have exactly the same behavior (given a few axioms) but are much faster than their counterparts.

These optimizations are on the microsecond level, but because this is a low-level library intended to be used within tight loops every cycle counts. Luckily these optimizations (in my opinion) do not degrade readability and if they do could be justified with a single comment.

All optimizations are tested using the `timeit` module, if you would like you may test them yourself and see the results. I have categorized the optimizations into *Less aggressive* and *Aggressive*.

If this sort of optimization is welcome, I would also like to perhaps optimize the use of flags within this library and it's dependents (hpack, h2) as the current system for flagging is quite slow.

#### Less aggressive optimization:

- `True if x else False` is faster than `bool(x)` **(318% speedup)**
- Frames with a defined length can be assigned that length immediately after parsing rather than checking the length again. **(290% speedup)**
- `True if x >> 31 else False` is faster than `bool(x & 0x80000000)` as long as the integer is masked. **(204% speedup)**
- `struct.Struct("!XX").[un]pack(x)` is faster than calling `struct.[un]pack("!XX", x)` repeatedly as long as struct format stays the same. **(52% speedup)**
- `x + y` is faster than `x | y` as long as both integers are masked. **(27% speedup)**
- `struct.Struct(">XX")` [un]packs faster than `struct.Struct("!XX")` and means the same thing. **(14% speedup)**
- `x & 0xFF` is faster than `x & 0x0000FF` because of how Python bit logic works. **(13% speedup)**

#### Aggressive optimization:

- Stream association per-frame can be checked faster if the same string is used rather than a new string for each frame. **(2% speedup)**
- `(x >> 8) & 0xFFFF` is faster than `(x & 0xFFFF00) >> 8` **(2% speedup)**