### PR TITLE
account for pad length field in flow control if zero valued

### DIFF
--- a/hyperframe/frame.py
+++ b/hyperframe/frame.py
@@ -279,7 +279,11 @@ class DataFrame(Padding, Frame):
         The length of the frame that needs to be accounted for when considering
         flow control.
         """
-        padding_len = self.total_padding + 1 if self.total_padding else 0
+        padding_len = 0
+        if 'PADDED' in self.flags:
+            # Account for extra 1-byte padding length field, which is still
+            # present if possibly zero-valued.
+            padding_len = self.total_padding + 1
         return len(self.data) + padding_len
 
 

--- a/test/test_frames.py
+++ b/test/test_frames.py
@@ -128,6 +128,14 @@ class TestDataFrame(object):
 
         assert f.flow_controlled_length == 19
 
+    def test_data_frame_zero_length_padding_calculates_flow_control_len(self):
+        f = DataFrame(1)
+        f.flags = set(['PADDED'])
+        f.data = b'testdata'
+        f.pad_length = 0
+
+        assert f.flow_controlled_length == len(b'testdata') + 1
+
     def test_data_frame_without_padding_calculates_flow_control_len(self):
         f = DataFrame(1)
         f.data = b'testdata'


### PR DESCRIPTION
It looks to me like the `DataFrame` class has a small edge case issue in the way it computes `flow_controlled_length()` - if padding flag is set on the frame but padding length is zero, the 1 byte length field doesn't get accounted for.