### PR TITLE
Provide a more useful link in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
     long_description=open('README.rst').read() + '\n\n' + open('HISTORY.rst').read(),
     author='Cory Benfield',
     author_email='cory@lukasa.co.uk',
-    url='http://hyper.rtfd.org',
+    url='https://python-hyper.org/hyperframe/en/latest/',
     packages=packages,
     package_data={'': ['LICENSE', 'README.rst', 'CONTRIBUTORS.rst', 'HISTORY.rst']},
     package_dir={'hyperframe': 'hyperframe'},


### PR DESCRIPTION
Click the "Homepage" link on https://pypi.org/project/hyperframe/ takes you to the home of the hyper project itself, which doesn’t mention hyperframe at all.