### PR TITLE
Import ABCs from collections.abc on Python 3.3+

### DIFF
--- a/hyperframe/flags.py
+++ b/hyperframe/flags.py
@@ -7,11 +7,16 @@ Defines basic Flag and Flags data structures.
 """
 import collections
 
+try:
+    import collections.abc as collections_abc
+except ImportError:
+    import collections as collections_abc
+
 
 Flag = collections.namedtuple("Flag", ["name", "bit"])
 
 
-class Flags(collections.MutableSet):
+class Flags(collections_abc.MutableSet):
     """
     A simple MutableSet implementation that will only accept known flags as
     elements.


### PR DESCRIPTION
The ABC classes in 'collections' were moved to 'collections.abc' in
Python 3.3, are deprecated as of Python 3.7 and due for removal in
Python 3.8.