### PR TITLE
Fix collections.abc deprecation, bump dependencies, drop py33 and pypy support

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,15 @@
+[run]
+branch = True
+source = hyperframe
+
+[report]
+fail_under = 100
+show_missing = True
+exclude_lines =
+    pragma: no cover
+
+[paths]
+source =
+    hyperframe/
+    .tox/*/lib/python*/site-packages/hyperframe
+    .tox/pypy*/site-packages/hyperframe

--- a/.coveragerc
+++ b/.coveragerc
@@ -12,4 +12,3 @@ exclude_lines =
 source =
     hyperframe/
     .tox/*/lib/python*/site-packages/hyperframe
-    .tox/pypy*/site-packages/hyperframe

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,6 @@ matrix:
   include:
     - python: "2.7"
       env: TOXENV=py27
-    - python: "3.3"
-      env: TOXENV=py33
     - python: "3.4"
       env: TOXENV=py34
     - python: "3.5"
@@ -26,10 +24,10 @@ matrix:
       env: TOXENV=py37
       dist: xenial
       sudo: true # required workaround for https://github.com/travis-ci/travis-ci/issues/9815
-    - python: "pypy"
-      env: TOXENV=pypy
     - python: "3.7"
       env: TOXENV=lint
+      dist: xenial
+      sudo: true # required workaround for https://github.com/travis-ci/travis-ci/issues/9815
 
 install:
   - "pip install -U pip setuptools"

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,8 @@ matrix:
       sudo: true # required workaround for https://github.com/travis-ci/travis-ci/issues/9815
     - python: "pypy"
       env: TOXENV=pypy
+    - python: "pypy3.5-5.10.1"
+      env: TOXENV=pypy3
     - python: "3.7"
       env: TOXENV=lint
       dist: xenial

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,8 @@ matrix:
       env: TOXENV=py37
       dist: xenial
       sudo: true # required workaround for https://github.com/travis-ci/travis-ci/issues/9815
+    - python: "pypy"
+      env: TOXENV=pypy
     - python: "3.7"
       env: TOXENV=lint
       dist: xenial

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,23 +1,38 @@
+sudo: false
 language: python
 
-python:
-  - "2.7"
-  - "3.3"
-  - "3.4"
-  - "3.5"
-  - "3.6"
-  - pypy
+branches:
+  only:
+    - master
+    - /^\d+\.\d+\.X$/
+
+cache:
+  directories:
+    - $HOME/.cache/pip
+
+matrix:
+  include:
+    - python: "2.7"
+      env: TOXENV=py27
+    - python: "3.3"
+      env: TOXENV=py33
+    - python: "3.4"
+      env: TOXENV=py34
+    - python: "3.5"
+      env: TOXENV=py35
+    - python: "3.6"
+      env: TOXENV=py36
+    - python: 3.7
+      env: TOXENV=py37
+      dist: xenial
+      sudo: true # required workaround for https://github.com/travis-ci/travis-ci/issues/9815
+    - python: "pypy"
+      env: TOXENV=pypy
+    - python: "3.7"
+      env: TOXENV=lint
 
 install:
-  - "pip install ."
-  - "pip install -r test_requirements.txt"
-  - "pip install flake8"
-before_script: "flake8 --max-complexity 10 hyperframe test"
+  - "pip install -U pip setuptools"
+  - "pip install -U tox"
 script:
-  - >
-      if [[ $TRAVIS_PYTHON_VERSION == pypy ]]; then
-        py.test test/
-      else
-        py.test -n 4 --cov hyperframe test/
-        coverage report -m --fail-under 100
-      fi
+  - tox

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,6 @@
-.PHONY: certs publish test
-
-certs:
-	curl http://ci.kennethreitz.org/job/ca-bundle/lastSuccessfulBuild/artifact/cacerts.pem -o hyper/certs.pem
+.PHONY: publish
 
 publish:
 	rm -rf dist/
 	python setup.py sdist bdist_wheel
 	twine upload -s dist/*
-
-test:
-	py.test -n 4 --cov hyperframe test/

--- a/hyperframe/flags.py
+++ b/hyperframe/flags.py
@@ -7,11 +7,16 @@ Defines basic Flag and Flags data structures.
 """
 import collections
 
+try:
+    from collections.abc import MutableSet
+except ImportError:  # pragma: no cover
+    # Python 2.7 compatibility
+    from collections import MutableSet
 
 Flag = collections.namedtuple("Flag", ["name", "bit"])
 
 
-class Flags(collections.MutableSet):
+class Flags(MutableSet):
     """
     A simple MutableSet implementation that will only accept known flags as
     elements.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,5 @@
 [wheel]
 universal = 1
+
+[tool:pytest]
+testpaths = test

--- a/setup.py
+++ b/setup.py
@@ -50,10 +50,10 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: Implementation :: CPython',
     ],
 )

--- a/test/test_frames.py
+++ b/test/test_frames.py
@@ -519,6 +519,19 @@ class TestGoAwayFrame(object):
         assert f.additional_data == b'hello'
         assert f.body_len == 13
 
+        s = (
+            b'\x00\x00\x08\x07\x00\x00\x00\x00\x00' +  # Frame header
+            b'\x00\x00\x00\x40' +                      # Last Stream ID
+            b'\x00\x00\x00\x20' +                      # Error Code
+            b''                                        # Additional data
+        )
+        f = decode_frame(s)
+
+        assert isinstance(f, GoAwayFrame)
+        assert f.flags == set()
+        assert f.additional_data == b''
+        assert f.body_len == 8
+
     def test_goaway_frame_never_has_a_stream(self):
         with pytest.raises(ValueError):
             GoAwayFrame(stream_id=1)

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,3 +1,4 @@
-pytest==3.8.1
-pytest-cov==2.6.0
+pytest==3.2.5
+pytest-cov==2.5.1
 pytest-xdist==1.23.0
+coverage==4.5.2

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,4 +1,4 @@
-pytest==3.2.5
-pytest-cov==2.5.1
-pytest-xdist==1.23.0
+pytest==4.0.1
+pytest-cov==2.6.0
+pytest-xdist==1.24.1
 coverage==4.5.2

--- a/tox.ini
+++ b/tox.ini
@@ -3,13 +3,14 @@ envlist = py27, py33, py34, py35, py36, pypy, lint
 
 [testenv]
 deps= -r{toxinidir}/test_requirements.txt
-commands= py.test -n 4 --cov hyperframe {toxinidir}/test/
+commands=
+    coverage run -m pytest --cov=hyperframe {posargs}
 
 [testenv:pypy]
 # temporarily disable coverage testing on PyPy due to performance problems
-commands= py.test -n 4 hyperframe {toxinidir}/test/
+commands= pytest -n 4 hyperframe
 
 [testenv:lint]
-basepython=python3.4
-deps = flake8==3.5.0
+basepython=python3.7
+deps = flake8==3.6.0
 commands = flake8 --max-complexity 10 hyperframe test

--- a/tox.ini
+++ b/tox.ini
@@ -1,14 +1,10 @@
 [tox]
-envlist = py27, py33, py34, py35, py36, pypy, lint
+envlist = py27, py34, py35, py36, py37, lint
 
 [testenv]
-deps= -r{toxinidir}/test_requirements.txt
-commands=
+deps = -r{toxinidir}/test_requirements.txt
+commands =
     coverage run -m pytest --cov=hyperframe {posargs}
-
-[testenv:pypy]
-# temporarily disable coverage testing on PyPy due to performance problems
-commands= pytest -n 4 hyperframe
 
 [testenv:lint]
 basepython=python3.7

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,15 @@
 [tox]
-envlist = py27, py34, py35, py36, py37, lint
+envlist = py27, py34, py35, py36, py37, pypy, lint
 
 [testenv]
 deps = -r{toxinidir}/test_requirements.txt
 commands =
     coverage run -m pytest --cov=hyperframe {posargs}
+
+[testenv:pypy]
+deps = -r{toxinidir}/test_requirements.txt
+commands =
+    pytest {posargs}
 
 [testenv:lint]
 basepython=python3.7

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py34, py35, py36, py37, pypy, lint
+envlist = py27, py34, py35, py36, py37, pypy, pypy3, lint
 
 [testenv]
 deps = -r{toxinidir}/test_requirements.txt
@@ -7,6 +7,11 @@ commands =
     coverage run -m pytest --cov=hyperframe {posargs}
 
 [testenv:pypy]
+deps = -r{toxinidir}/test_requirements.txt
+commands =
+    pytest {posargs}
+
+[testenv:pypy3]
 deps = -r{toxinidir}/test_requirements.txt
 commands =
     pytest {posargs}


### PR DESCRIPTION
* fix collections.abc deprecation: closes #123 
* bump dependencies for test requirements: closes #122
* add support for Python 3.7 and run tests against it
* run tests for pypy2 and pypy3 on Travis
* drop Python 3.3 support (basically impossible to test with modern CI systems and dependencies)
* adopt travis+tox+coveragerc architecture from other hyper projects
