### PR TITLE
Add a new SETTINGS_ENABLE_CONNECT_PROTOCOL settings paramter

### DIFF
--- a/hyperframe/frame.py
+++ b/hyperframe/frame.py
@@ -395,6 +395,8 @@ class SettingsFrame(Frame):
     MAX_FRAME_SIZE = 0x05
     #: The byte that signals the SETTINGS_MAX_HEADER_LIST_SIZE setting.
     MAX_HEADER_LIST_SIZE = 0x06
+    #: The byte that signals connect protocol support.
+    SETTINGS_ENABLE_CONNECT_PROTOCOL = 0x08
 
     def __init__(self, stream_id=0, settings=None, **kwargs):
         super(SettingsFrame, self).__init__(stream_id, **kwargs)

--- a/test/test_frames.py
+++ b/test/test_frames.py
@@ -306,13 +306,14 @@ class TestRstStreamFrame(object):
 
 class TestSettingsFrame(object):
     serialized = (
-        b'\x00\x00\x24\x04\x01\x00\x00\x00\x00' +  # Frame header
+        b'\x00\x00\x2A\x04\x01\x00\x00\x00\x00' +  # Frame header
         b'\x00\x01\x00\x00\x10\x00' +              # HEADER_TABLE_SIZE
         b'\x00\x02\x00\x00\x00\x00' +              # ENABLE_PUSH
         b'\x00\x03\x00\x00\x00\x64' +              # MAX_CONCURRENT_STREAMS
         b'\x00\x04\x00\x00\xFF\xFF' +              # INITIAL_WINDOW_SIZE
         b'\x00\x05\x00\x00\x40\x00' +              # MAX_FRAME_SIZE
-        b'\x00\x06\x00\x00\xFF\xFF'                # MAX_HEADER_LIST_SIZE
+        b'\x00\x06\x00\x00\xFF\xFF' +              # MAX_HEADER_LIST_SIZE
+        b'\x00\x08\x00\x00\x00\x01'                # SETTINGS_ENABLE_CONNECT_PROTOCOL # noqa: E501
     )
 
     settings = {
@@ -322,6 +323,7 @@ class TestSettingsFrame(object):
         SettingsFrame.INITIAL_WINDOW_SIZE: 65535,
         SettingsFrame.MAX_FRAME_SIZE: 16384,
         SettingsFrame.MAX_HEADER_LIST_SIZE: 65535,
+        SettingsFrame.SETTINGS_ENABLE_CONNECT_PROTOCOL: 1,
     }
 
     def test_settings_frame_has_only_one_flag(self):
@@ -359,7 +361,7 @@ class TestSettingsFrame(object):
         assert isinstance(f, SettingsFrame)
         assert f.flags == set(['ACK'])
         assert f.settings == self.settings
-        assert f.body_len == 36
+        assert f.body_len == 42
 
     def test_settings_frames_never_have_streams(self):
         with pytest.raises(ValueError):


### PR DESCRIPTION
This parameter is introduced in RFC 8441 (Websockets over HTTP/2) and
assigned the 0x8 code
(http://www.iana.org/assignments/http2-parameters/http2-parameters.xhtml).
Support here allows for a future hyper-h2 support and onwards towards
a server that supports Websockets over HTTP/2.