### PR TITLE
Update 6.0.0dev0 in HISTORY.rst

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,8 @@ Release History
 6.0.0dev0
 ---------
 
+- Added support Python 3.8
+
 5.1.0 (2017-04-24)
 ------------------
 


### PR DESCRIPTION
https://github.com/python-hyper/hyperframe/pull/126 takes care of `collections -> collections.abc` which is needed for Python 3.8