### PR TITLE
run http2-frame-test-case test cases and fix padding

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@master
+      with:
+        submodules: recursive
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v1
       with:

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "test/http2-frame-test-case"]
+	path = test/http2-frame-test-case
+	url = https://github.com/http2jp/http2-frame-test-case.git

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,10 @@ Release History
 6.0.0dev0
 ---------
 
+**Other Changes**
+
+- Drop support for Python 2.7, 3.4, 3.5, pypy and support 3.8.
+
 5.2.0 (2019-01-18)
 ------------------
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -12,6 +12,7 @@ Release History
 
 - Fixed padding parsing for ``PushPromiseFrame``.
 - Fixed unchecked frame length for ``PriorityFrame``. It now correctly raises ``InvalidFrameError``.
+- Fixed promised stream id parsing for ``PushPromiseFrame``.
 
 **Other Changes**
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -11,6 +11,7 @@ Release History
 **Bugfixes**
 
 - Fixed padding parsing for ``PushPromiseFrame``.
+- Fixed unchecked frame length for ``PriorityFrame``. It now correctly raises ``InvalidFrameError``.
 
 **Other Changes**
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -15,6 +15,7 @@ Release History
 - Fixed promised stream id parsing for ``PushPromiseFrame``.
 - Fixed unchecked frame length for ``WindowUpdateFrame``. It now correctly raises ``InvalidFrameError``.
 - Fixed window increment value range validation. It must be 1 <= increment <= 2^31-1.
+- Fixed parsing of ``SettingsFrame`` with mutual exclusion of ACK flag and payload.
 
 **Other Changes**
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,6 +8,10 @@ Release History
 
 - Deprecate ``total_padding`` - use `pad_length` instead.
 
+**Bugfixes**
+
+- Fixed padding parsing for ``PushPromiseFrame``.
+
 **Other Changes**
 
 - Drop support for Python 2.7, 3.4, 3.5, pypy and support 3.8.

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,10 @@ Release History
 6.0.0dev0
 ---------
 
+**API Changes (Backward-compatible)**
+
+- Deprecate ``total_padding`` - use `pad_length` instead.
+
 **Other Changes**
 
 - Drop support for Python 2.7, 3.4, 3.5, pypy and support 3.8.

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -13,6 +13,8 @@ Release History
 - Fixed padding parsing for ``PushPromiseFrame``.
 - Fixed unchecked frame length for ``PriorityFrame``. It now correctly raises ``InvalidFrameError``.
 - Fixed promised stream id parsing for ``PushPromiseFrame``.
+- Fixed unchecked frame length for ``WindowUpdateFrame``. It now correctly raises ``InvalidFrameError``.
+- Fixed window increment value range validation. It must be 1 <= increment <= 2^31-1.
 
 **Other Changes**
 

--- a/hyperframe/frame.py
+++ b/hyperframe/frame.py
@@ -622,10 +622,21 @@ class WindowUpdateFrame(Frame):
         return _STRUCT_L.pack(self.window_increment & 0x7FFFFFFF)
 
     def parse_body(self, data):
+        if len(data) > 4:
+            raise InvalidFrameError(
+                "WINDOW_UPDATE frame must have 4 byte length: got %s" %
+                len(data)
+            )
+
         try:
             self.window_increment = _STRUCT_L.unpack(data)[0]
         except struct.error:
             raise InvalidFrameError("Invalid WINDOW_UPDATE body")
+
+        if not 1 <= self.window_increment <= 2**31-1:
+            raise InvalidFrameError(
+                "WINDOW_UPDATE increment must be between 1 to 2^31-1"
+            )
 
         self.body_len = 4
 

--- a/hyperframe/frame.py
+++ b/hyperframe/frame.py
@@ -485,6 +485,12 @@ class PushPromiseFrame(Padding, Frame):
         )
         self.body_len = len(data)
 
+        if self.promised_stream_id == 0 or self.promised_stream_id % 2 != 0:
+            raise InvalidFrameError(
+                "Invalid PUSH_PROMISE promised stream id: %s" %
+                self.promised_stream_id
+            )
+
         if self.pad_length and self.pad_length >= self.body_len:
             raise InvalidPaddingError("Padding is too long.")
 

--- a/hyperframe/frame.py
+++ b/hyperframe/frame.py
@@ -323,8 +323,14 @@ class PriorityFrame(Priority, Frame):
         return self.serialize_priority_data()
 
     def parse_body(self, data):
+        if len(data) > 5:
+            raise InvalidFrameError(
+                "PRIORITY must have 5 byte body: actual length %s." %
+                len(data)
+            )
+
         self.parse_priority_data(data)
-        self.body_len = len(data)
+        self.body_len = 5
 
 
 class RstStreamFrame(Frame):

--- a/hyperframe/frame.py
+++ b/hyperframe/frame.py
@@ -425,6 +425,12 @@ class SettingsFrame(Frame):
                          for setting, value in self.settings.items()])
 
     def parse_body(self, data):
+        if 'ACK' in self.flags and len(data) > 0:
+            raise InvalidFrameError(
+                "SETTINGS ack frame must not have payload: got %s bytes" %
+                len(data)
+            )
+
         body_len = 0
         for i in range(0, len(data), 6):
             try:

--- a/hyperframe/frame.py
+++ b/hyperframe/frame.py
@@ -474,7 +474,9 @@ class PushPromiseFrame(Padding, Frame):
         except struct.error:
             raise InvalidFrameError("Invalid PUSH_PROMISE body")
 
-        self.data = data[padding_data_length + 4:].tobytes()
+        self.data = (
+            data[padding_data_length + 4:len(data)-self.pad_length].tobytes()
+        )
         self.body_len = len(data)
 
         if self.pad_length and self.pad_length >= self.body_len:

--- a/test/test_external_collection.py
+++ b/test/test_external_collection.py
@@ -1,0 +1,85 @@
+# https://github.com/http2jp/http2-frame-test-case
+
+import os
+import json
+import pytest
+from hyperframe.frame import Frame
+
+tc_filepaths = []
+root = os.path.dirname(__file__)
+path = os.walk(os.path.join(root, "http2-frame-test-case"))
+for dirpath, dirnames, filenames in path:
+    for filename in filenames:
+        if os.path.splitext(filename)[1] != ".json":
+            continue
+        tc_filepaths.append(
+            os.path.relpath(os.path.join(dirpath, filename), root)
+        )
+
+
+def check_valid_frame(tc, data):  # noqa: C901
+    new_frame, length = Frame.parse_frame_header(data[:9], strict=True)
+    new_frame.parse_body(memoryview(data[9:9 + length]))
+
+    assert tc["frame"]["length"] == length
+    assert tc["frame"]["stream_identifier"] == new_frame.stream_id
+    assert tc["frame"]["type"] == new_frame.type
+
+    flags = 0
+    for flag, flag_bit in new_frame.defined_flags:
+        if flag in new_frame.flags:
+            flags |= flag_bit
+    assert tc["frame"]["flags"] == flags
+
+    p = tc["frame"]["frame_payload"]
+    if "header_block_fragment" in p:
+        assert p["header_block_fragment"] == new_frame.data.decode()
+    if "data" in p:
+        assert p["data"] == new_frame.data.decode()
+    if "padding" in p:
+        # the padding data itself is not retained by hyperframe after parsing
+        pass
+    if "padding_length" in p and p["padding_length"]:
+        assert p["padding_length"] == new_frame.pad_length
+    if "error_code" in p:
+        assert p["error_code"] == new_frame.error_code
+    if "additional_debug_data" in p:
+        assert p["additional_debug_data"].encode() == new_frame.additional_data
+    if "last_stream_id" in p:
+        assert p["last_stream_id"] == new_frame.last_stream_id
+    if "stream_dependency" in p:
+        assert p["stream_dependency"] or 0 == new_frame.depends_on
+    if "weight" in p and p["weight"]:
+        assert p["weight"] - 1 == new_frame.stream_weight
+    if "exclusive" in p:
+        assert (p["exclusive"] or False) == new_frame.exclusive
+    if "opaque_data" in p:
+        assert p["opaque_data"].encode() == new_frame.opaque_data
+    if "promised_stream_id" in p:
+        assert p["promised_stream_id"] == new_frame.promised_stream_id
+    if "settings" in p:
+        assert dict(p["settings"]) == new_frame.settings
+    if "window_size_increment" in p:
+        assert p["window_size_increment"] == new_frame.window_increment
+
+
+class TestExternalCollection:
+    @pytest.mark.parametrize('tc_filepath', tc_filepaths)
+    def test(self, tc_filepath):
+        with open(os.path.join(root, tc_filepath)) as f:
+            tc = json.load(f)
+
+        data = bytes.fromhex(tc["wire"])
+
+        if tc["error"] is None and tc["frame"]:
+            check_valid_frame(tc, data)
+        elif tc["error"] and tc["frame"] is None:
+            with pytest.raises(Exception):
+                new_frame, length = Frame.parse_frame_header(
+                    data[:9],
+                    strict=True
+                )
+                new_frame.parse_body(memoryview(data[9:9 + length]))
+                assert length == new_frame.body_len
+        else:
+            pytest.fail("unexpected test case: {} {}".format(tc_filepath, tc))

--- a/test/test_frames.py
+++ b/test/test_frames.py
@@ -406,6 +406,21 @@ class TestPushPromiseFrame(object):
         assert f.data == b'hello world'
         assert f.body_len == 15
 
+    def test_push_promise_frame_with_padding(self):
+        s = (
+            b'\x00\x00\x17\x05\x0C\x00\x00\x00\x01' +
+            b'\x07\x00\x00\x00\x04' +
+            b'hello world' +
+            b'padding'
+        )
+        f = decode_frame(s)
+
+        assert isinstance(f, PushPromiseFrame)
+        assert f.flags == set(['END_HEADERS', 'PADDED'])
+        assert f.promised_stream_id == 4
+        assert f.data == b'hello world'
+        assert f.body_len == 23
+
     def test_push_promise_frame_with_invalid_padding_fails_to_parse(self):
         # This frame has a padding length of 6 bytes, but a total length of
         # only 5.

--- a/test/test_frames.py
+++ b/test/test_frames.py
@@ -262,6 +262,12 @@ class TestPriorityFrame(object):
         assert f.exclusive is True
         assert f.body_len == 5
 
+    def test_priority_frame_invalid(self):
+        with pytest.raises(ValueError):
+            decode_frame(
+                b'\x00\x00\x06\x02\x00\x00\x00\x00\x01\x80\x00\x00\x04\x40\xFF'
+            )
+
     def test_priority_frame_comes_on_a_stream(self):
         with pytest.raises(ValueError):
             PriorityFrame(0)

--- a/test/test_frames.py
+++ b/test/test_frames.py
@@ -437,12 +437,21 @@ class TestPushPromiseFrame(object):
 
     def test_push_promise_frame_with_no_length_parses(self):
         # Fixes issue with empty data frames raising InvalidPaddingError.
-        f = PushPromiseFrame(1)
+        f = PushPromiseFrame(1, 2)
         f.data = b''
         data = f.serialize()
 
         new_frame = decode_frame(data)
         assert new_frame.data == b''
+
+    def test_push_promise_frame_invalid(self):
+        data = PushPromiseFrame(1, 0).serialize()
+        with pytest.raises(InvalidFrameError):
+            decode_frame(data)
+
+        data = PushPromiseFrame(1, 3).serialize()
+        with pytest.raises(InvalidFrameError):
+            decode_frame(data)
 
     def test_short_push_promise_errors(self):
         s = (

--- a/test/test_frames.py
+++ b/test/test_frames.py
@@ -604,9 +604,18 @@ class TestWindowUpdateFrame(object):
 
     def test_short_windowupdate_frame_errors(self):
         s = b'\x00\x00\x04\x08\x00\x00\x00\x00\x00\x00\x00\x02'  # -1 byte
-
         with pytest.raises(InvalidFrameError):
             decode_frame(s)
+
+        s = b'\x00\x00\x05\x08\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02'
+        with pytest.raises(InvalidFrameError):
+            decode_frame(s)
+
+        with pytest.raises(InvalidFrameError):
+            decode_frame(WindowUpdateFrame(0).serialize())
+
+        with pytest.raises(InvalidFrameError):
+            decode_frame(WindowUpdateFrame(2**31).serialize())
 
 
 class TestHeadersFrame(object):

--- a/test/test_frames.py
+++ b/test/test_frames.py
@@ -361,13 +361,25 @@ class TestSettingsFrame(object):
         with pytest.raises(ValueError):
             SettingsFrame(settings=self.settings, flags=('ACK',))
 
+        with pytest.raises(ValueError):
+            decode_frame(self.serialized)
+
     def test_settings_frame_parses_properly(self):
-        f = decode_frame(self.serialized)
+        # unset the ACK flag to allow correct parsing
+        data = self.serialized[:4] + b"\x00" + self.serialized[5:]
+
+        f = decode_frame(data)
 
         assert isinstance(f, SettingsFrame)
-        assert f.flags == set(['ACK'])
+        assert f.flags == set()
         assert f.settings == self.settings
         assert f.body_len == 42
+
+    def test_settings_frame_invalid_body_length(self):
+        with pytest.raises(ValueError):
+            decode_frame(
+                b'\x00\x00\x2A\x04\x00\x00\x00\x00\x00\xFF\xFF\xFF\xFF'
+            )
 
     def test_settings_frames_never_have_streams(self):
         with pytest.raises(ValueError):

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,12 @@
 [tox]
 envlist = py36, py37, py38, pypy3, lint
 
+[gh-actions]
+python =
+    3.6: py36
+    3.7: py37
+    3.8: py38, lint
+
 [testenv]
 deps =
     pytest==5.4.3
@@ -10,7 +16,7 @@ deps =
 commands =
     pytest --cov=hyperframe {posargs}
 
-[testenv:pypy]
+[testenv:pypy3]
 # temporarily disable coverage testing on PyPy due to performance problems
 commands = pytest {posargs}
 


### PR DESCRIPTION
fixes #68 

This PR runs the https://github.com/http2jp/http2-frame-test-case test cases as git-submodule with a small pytest wrapper to load them dynamically.

This PR fixes and actual serious bug with regard to padding in PUSH_PROMISE frames.

This PR contains various commits to fix individual bugs or test failures for frame parsing. Most of them are about increased input validation and more strict/correct interpretation of the RFC.