### PR TITLE
use new exception type for data protocol errors

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,16 @@ Release History
 6.0.0+dev
 ---------
 
+**Backwards Incompatible API Changes**
+
+- Introduce ``HyperframeError`` base exception class for all errors raised within hyperframe.
+- Change exception base class of ``UnknownFrameError`` to ``HyperframeError``
+- Change exception base class of ``InvalidPaddingError`` to ``HyperframeError``
+- Change exception base class of ``InvalidFrameError`` to ``HyperframeError``
+- Invalid frames with wrong stream id (zero vs. non-zero) now raise ``InvalidDataError``.
+- Invalid SETTINGS frames (non-empty but ACK) now raise ``InvalidDataError``.
+- Invalid ALTSVC frames with non-bytestring field or origin now raise ``InvalidDataError``.
+
 **API Changes (Backward-compatible)**
 
 - Deprecate ``total_padding`` - use `pad_length` instead.
@@ -12,16 +22,10 @@ Release History
 
 - Fixed padding parsing for ``PushPromiseFrame``.
 - Fixed unchecked frame length for ``PriorityFrame``. It now correctly raises ``InvalidFrameError``.
-- Fixed promised stream id parsing for ``PushPromiseFrame``.
+- Fixed promised stream id validation for ``PushPromiseFrame``. It now raises ``InvalidDataError``.
 - Fixed unchecked frame length for ``WindowUpdateFrame``. It now correctly raises ``InvalidFrameError``.
-- Fixed window increment value range validation. It must be 1 <= increment <= 2^31-1.
+- Fixed window increment value range validation. It now raises ``InvalidDataError``.
 - Fixed parsing of ``SettingsFrame`` with mutual exclusion of ACK flag and payload.
-- Invalid frames with wrong stream id (zero vs. non-zero) now raise ``InvalidFrameError``, not
-  ``ValueError``. Note that ``InvalidFrameError`` is a ``ValueError`` subclass.
-- Invalid SETTINGS frames (non-empty but ACK) now raise ``InvalidFrameError``, not
-  ``ValueError``. Note that ``InvalidFrameError`` is a ``ValueError`` subclass.
-- Invalid ALTSVC frames with non-bytestring field or origin now raise ``InvalidFrameError``, not
-  ``ValueError``. Note that ``InvalidFrameError`` is a ``ValueError`` subclass.
 
 **Other Changes**
 

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -72,6 +72,9 @@ you need is not present!
 Exceptions
 ----------
 
+.. autoclass:: hyperframe.exceptions.HyperframeError
+   :members:
+
 .. autoclass:: hyperframe.exceptions.UnknownFrameError
    :members:
 
@@ -79,4 +82,7 @@ Exceptions
    :members:
 
 .. autoclass:: hyperframe.exceptions.InvalidFrameError
+   :members:
+
+.. autoclass:: hyperframe.exceptions.InvalidDataError
    :members:

--- a/src/hyperframe/exceptions.py
+++ b/src/hyperframe/exceptions.py
@@ -7,9 +7,20 @@ Defines the exceptions that can be thrown by hyperframe.
 """
 
 
-class UnknownFrameError(ValueError):
+class HyperframeError(Exception):
+    """
+    The base class for all exceptions for the hyperframe module.
+
+    .. versionadded:: 6.0.0
+    """
+
+
+class UnknownFrameError(HyperframeError):
     """
     A frame of unknown type was received.
+
+    .. versionchanged:: 6.0.0
+        Changed base class from `ValueError` to :class:`HyperframeError`
     """
     def __init__(self, frame_type, length):
         #: The type byte of the unknown frame that was received.
@@ -25,17 +36,32 @@ class UnknownFrameError(ValueError):
         )
 
 
-class InvalidPaddingError(ValueError):
+class InvalidPaddingError(HyperframeError):
     """
     A frame with invalid padding was received.
+
+    .. versionchanged:: 6.0.0
+        Changed base class from `ValueError` to :class:`HyperframeError`
     """
     pass
 
 
-class InvalidFrameError(ValueError):
+class InvalidFrameError(HyperframeError):
     """
     Parsing a frame failed because the data was not laid out appropriately.
 
     .. versionadded:: 3.0.2
+
+    .. versionchanged:: 6.0.0
+        Changed base class from `ValueError` to :class:`HyperframeError`
+    """
+    pass
+
+
+class InvalidDataError(HyperframeError):
+    """
+    Content or data of a frame was is invalid or violates the specification.
+
+    .. versionadded:: 6.0.0
     """
     pass

--- a/test/test_frames.py
+++ b/test/test_frames.py
@@ -5,7 +5,7 @@ from hyperframe.frame import (
     ContinuationFrame, AltSvcFrame, ExtensionFrame
 )
 from hyperframe.exceptions import (
-    UnknownFrameError, InvalidPaddingError, InvalidFrameError
+    UnknownFrameError, InvalidPaddingError, InvalidFrameError, InvalidDataError
 )
 import pytest
 
@@ -179,7 +179,7 @@ class TestDataFrame:
         assert f.flow_controlled_length == 8
 
     def test_data_frame_comes_on_a_stream(self):
-        with pytest.raises(InvalidFrameError):
+        with pytest.raises(InvalidDataError):
             DataFrame(0)
 
     def test_long_data_frame(self):
@@ -269,7 +269,7 @@ class TestPriorityFrame:
             )
 
     def test_priority_frame_comes_on_a_stream(self):
-        with pytest.raises(InvalidFrameError):
+        with pytest.raises(InvalidDataError):
             PriorityFrame(0)
 
     def test_short_priority_frame_errors(self):
@@ -301,7 +301,7 @@ class TestRstStreamFrame:
         assert f.body_len == 4
 
     def test_rst_stream_frame_comes_on_a_stream(self):
-        with pytest.raises(InvalidFrameError):
+        with pytest.raises(InvalidDataError):
             RstStreamFrame(0)
 
     def test_rst_stream_frame_must_have_body_length_four(self):
@@ -358,10 +358,10 @@ class TestSettingsFrame:
         assert 'ACK' in f.flags
 
     def test_settings_frame_ack_and_settings(self):
-        with pytest.raises(InvalidFrameError):
+        with pytest.raises(InvalidDataError):
             SettingsFrame(settings=self.settings, flags=('ACK',))
 
-        with pytest.raises(InvalidFrameError):
+        with pytest.raises(InvalidDataError):
             decode_frame(self.serialized)
 
     def test_settings_frame_parses_properly(self):
@@ -382,11 +382,11 @@ class TestSettingsFrame:
             )
 
     def test_settings_frames_never_have_streams(self):
-        with pytest.raises(InvalidFrameError):
+        with pytest.raises(InvalidDataError):
             SettingsFrame(stream_id=1)
 
     def test_short_settings_frame_errors(self):
-        with pytest.raises(InvalidFrameError):
+        with pytest.raises(InvalidDataError):
             decode_frame(self.serialized[:-2])
 
 
@@ -458,11 +458,11 @@ class TestPushPromiseFrame:
 
     def test_push_promise_frame_invalid(self):
         data = PushPromiseFrame(1, 0).serialize()
-        with pytest.raises(InvalidFrameError):
+        with pytest.raises(InvalidDataError):
             decode_frame(data)
 
         data = PushPromiseFrame(1, 3).serialize()
-        with pytest.raises(InvalidFrameError):
+        with pytest.raises(InvalidDataError):
             decode_frame(data)
 
     def test_short_push_promise_errors(self):
@@ -513,7 +513,7 @@ class TestPingFrame:
         assert f.body_len == 8
 
     def test_ping_frame_never_has_a_stream(self):
-        with pytest.raises(InvalidFrameError):
+        with pytest.raises(InvalidDataError):
             PingFrame(stream_id=1)
 
     def test_ping_frame_has_no_more_than_body_length_8(self):
@@ -577,7 +577,7 @@ class TestGoAwayFrame:
         assert f.body_len == 8
 
     def test_goaway_frame_never_has_a_stream(self):
-        with pytest.raises(InvalidFrameError):
+        with pytest.raises(InvalidDataError):
             GoAwayFrame(stream_id=1)
 
     def test_short_goaway_frame_errors(self):
@@ -623,10 +623,10 @@ class TestWindowUpdateFrame:
         with pytest.raises(InvalidFrameError):
             decode_frame(s)
 
-        with pytest.raises(InvalidFrameError):
+        with pytest.raises(InvalidDataError):
             decode_frame(WindowUpdateFrame(0).serialize())
 
-        with pytest.raises(InvalidFrameError):
+        with pytest.raises(InvalidDataError):
             decode_frame(WindowUpdateFrame(2**31).serialize())
 
 
@@ -829,14 +829,14 @@ class TestAltSvcFrame:
             decode_frame(self.payload_with_origin[:10])
 
     def test_altsvc_with_unicode_origin_fails(self):
-        with pytest.raises(InvalidFrameError):
+        with pytest.raises(InvalidDataError):
             AltSvcFrame(
                 stream_id=0, origin=u'hello', field=b'h2=":8000"; ma=60'
 
             )
 
     def test_altsvc_with_unicode_field_fails(self):
-        with pytest.raises(InvalidFrameError):
+        with pytest.raises(InvalidDataError):
             AltSvcFrame(
                 stream_id=0, origin=b'hello', field=u'h2=":8000"; ma=60'
             )


### PR DESCRIPTION
This PR restructures the hyperframe exception types.

* Introduce a new `HyperframeError` base class and use it for all custom exception (instead of `ValueError`).
* Split frame parsing errors from frame header or payload data errors: `InvalidFrameError` vs. `InvalidDataError`.

This fixes a regression in hyper-h2 which needs to differentiate between the error types to send the correct error code back to the other endpoint: https://github.com/python-hyper/hyper-h2/pull/1238