### PR TITLE
Debug++

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,8 @@ Release History
 **API Changes (Backward-compatible)**
 
 - Deprecate ``total_padding`` - use `pad_length` instead.
+- Improve repr() output for all frame classes.
+- Introduce Frame.explain(data) for quick introspection of raw data.
 
 **Bugfixes**
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,3 +16,6 @@ exclude_lines =
 source =
     src
     .tox/*/site-packages
+
+[flake8]
+max-line-length = 120

--- a/src/hyperframe/flags.py
+++ b/src/hyperframe/flags.py
@@ -23,6 +23,9 @@ class Flags(MutableSet):
         self._valid_flags = set(flag.name for flag in defined_flags)
         self._flags = set()
 
+    def __repr__(self):
+        return repr(sorted(list(self._flags)))
+
     def __contains__(self, x):
         return self._flags.__contains__(x)
 

--- a/src/hyperframe/frame.py
+++ b/src/hyperframe/frame.py
@@ -68,10 +68,19 @@ class Frame:
 
         if (not self.stream_id and
            self.stream_association == _STREAM_ASSOC_HAS_STREAM):
-            raise InvalidDataError('Stream ID must be non-zero')
+            raise InvalidDataError(
+                'Stream ID must be non-zero for {}'.format(
+                    type(self).__name__,
+                )
+            )
         if (self.stream_id and
            self.stream_association == _STREAM_ASSOC_NO_STREAM):
-            raise InvalidDataError('Stream ID must be zero')
+            raise InvalidDataError(
+                'Stream ID must be zero for {} with stream_id: {}'.format(
+                    type(self).__name__,
+                    self.stream_id,
+                )
+            )
 
     def __repr__(self):
         flags = ", ".join(self.flags) or "None"

--- a/src/hyperframe/frame.py
+++ b/src/hyperframe/frame.py
@@ -83,18 +83,36 @@ class Frame:
             )
 
     def __repr__(self):
-        flags = ", ".join(self.flags) or "None"
-        body = binascii.hexlify(self.serialize_body()).decode('ascii')
-        if len(body) > 20:
-            body = body[:20] + "..."
         return (
-            "{type}(Stream: {stream}; Flags: {flags}): {body}"
+            "{}(stream_id: {}; flags: {}): {}"
         ).format(
-            type=type(self).__name__,
-            stream=self.stream_id,
-            flags=flags,
-            body=body,
+            type(self).__name__,
+            self.stream_id,
+            ", ".join(sorted(self.flags)) or "None",
+            self._body_repr(),
         )
+
+    def _body_repr(self):
+        # More specific implementation may be provided by subclasses of Frame.
+        # This fallback shows the serialized (and truncated) body content.
+        return _raw_data_repr(self.serialize_body())
+
+    @staticmethod
+    def explain(data):
+        """
+        Takes a bytestring and tries to parse a single frame and print it.
+
+        This function is only provided for debugging purposes.
+
+        :param data: A memoryview object containing the raw data of at least
+                     one complete frame (header and body).
+
+        .. versionadded:: 6.0.0
+        """
+        frame, length = Frame.parse_frame_header(data[:9])
+        frame.parse_body(data[9:9 + length])
+        print(frame)
+        return frame, length
 
     @staticmethod
     def parse_frame_header(header, strict=False):
@@ -331,6 +349,13 @@ class PriorityFrame(Priority, Frame):
 
     stream_association = _STREAM_ASSOC_HAS_STREAM
 
+    def _body_repr(self):
+        return "exclusive: {}, depends_on: {}, stream_weight: {}".format(
+            self.exclusive,
+            self.depends_on,
+            self.stream_weight
+        )
+
     def serialize_body(self):
         return self.serialize_priority_data()
 
@@ -367,6 +392,11 @@ class RstStreamFrame(Frame):
 
         #: The error code used when resetting the stream.
         self.error_code = error_code
+
+    def _body_repr(self):
+        return "error_code: {}".format(
+            self.error_code,
+        )
 
     def serialize_body(self):
         return _STRUCT_L.pack(self.error_code)
@@ -434,6 +464,11 @@ class SettingsFrame(Frame):
         #: A dictionary of the setting type byte to the value of the setting.
         self.settings = settings or {}
 
+    def _body_repr(self):
+        return "settings: {}".format(
+            self.settings,
+        )
+
     def serialize_body(self):
         return b''.join([_STRUCT_HL.pack(setting & 0xFF, value)
                          for setting, value in self.settings.items()])
@@ -483,6 +518,12 @@ class PushPromiseFrame(Padding, Frame):
         #: The HPACK-encoded header block for the simulated request on the new
         #: stream.
         self.data = data
+
+    def _body_repr(self):
+        return "promised_stream_id: {}, data: {}".format(
+            self.promised_stream_id,
+            _raw_data_repr(self.data),
+        )
 
     def serialize_body(self):
         padding_data = self.serialize_padding_data()
@@ -534,6 +575,11 @@ class PingFrame(Frame):
 
         #: The opaque data sent in this PING frame, as a bytestring.
         self.opaque_data = opaque_data
+
+    def _body_repr(self):
+        return "opaque_data: {}".format(
+            self.opaque_data,
+        )
 
     def serialize_body(self):
         if len(self.opaque_data) > 8:
@@ -588,6 +634,13 @@ class GoAwayFrame(Frame):
         #: Any additional data sent in the GOAWAY.
         self.additional_data = additional_data
 
+    def _body_repr(self):
+        return "last_stream_id: {}, error_code: {}, additional_data: {}".format(
+            self.last_stream_id,
+            self.error_code,
+            self.additional_data,
+        )
+
     def serialize_body(self):
         data = _STRUCT_LL.pack(
             self.last_stream_id & 0x7FFFFFFF,
@@ -637,6 +690,11 @@ class WindowUpdateFrame(Frame):
 
         #: The amount the flow control window is to be incremented.
         self.window_increment = window_increment
+
+    def _body_repr(self):
+        return "window_increment: {}".format(
+            self.window_increment,
+        )
 
     def serialize_body(self):
         return _STRUCT_L.pack(self.window_increment & 0x7FFFFFFF)
@@ -692,6 +750,14 @@ class HeadersFrame(Padding, Priority, Frame):
         #: The HPACK-encoded header block.
         self.data = data
 
+    def _body_repr(self):
+        return "exclusive: {}, depends_on: {}, stream_weight: {}, data: {}".format(
+            self.exclusive,
+            self.depends_on,
+            self.stream_weight,
+            _raw_data_repr(self.data),
+        )
+
     def serialize_body(self):
         padding_data = self.serialize_padding_data()
         padding = b'\0' * self.pad_length
@@ -745,6 +811,11 @@ class ContinuationFrame(Frame):
         #: The HPACK-encoded header block.
         self.data = data
 
+    def _body_repr(self):
+        return "data: {}".format(
+            _raw_data_repr(self.data),
+        )
+
     def serialize_body(self):
         return self.data
 
@@ -781,6 +852,12 @@ class AltSvcFrame(Frame):
             raise InvalidDataError("AltSvc field must be a bytestring.")
         self.origin = origin
         self.field = field
+
+    def _body_repr(self):
+        return "origin: {}, field: {}".format(
+            self.origin,
+            self.field,
+        )
 
     def serialize_body(self):
         origin_len = _STRUCT_H.pack(len(self.origin))
@@ -819,10 +896,18 @@ class ExtensionFrame(Frame):
 
     stream_association = _STREAM_ASSOC_EITHER
 
-    def __init__(self, type, stream_id, **kwargs):
+    def __init__(self, type, stream_id, flag_byte=0x0, body=b'', **kwargs):
         super().__init__(stream_id, **kwargs)
         self.type = type
-        self.flag_byte = None
+        self.flag_byte = flag_byte
+        self.body = body
+
+    def _body_repr(self):
+        return "type: {}, flag_byte: {}, body: {}".format(
+            self.type,
+            self.flag_byte,
+            _raw_data_repr(self.body),
+        )
 
     def parse_flags(self, flag_byte):
         """
@@ -854,6 +939,15 @@ class ExtensionFrame(Frame):
         )
 
         return header + self.body
+
+
+def _raw_data_repr(data):
+    if not data:
+        return "None"
+    r = binascii.hexlify(data).decode('ascii')
+    if len(r) > 20:
+        r = r[:20] + "..."
+    return r
 
 
 _FRAME_CLASSES = [

--- a/src/hyperframe/frame.py
+++ b/src/hyperframe/frame.py
@@ -76,7 +76,7 @@ class Frame:
         if (self.stream_id and
            self.stream_association == _STREAM_ASSOC_NO_STREAM):
             raise InvalidDataError(
-                'Stream ID must be zero for {} with stream_id: {}'.format(
+                'Stream ID must be zero for {} with stream_id={}'.format(
                     type(self).__name__,
                     self.stream_id,
                 )
@@ -84,11 +84,11 @@ class Frame:
 
     def __repr__(self):
         return (
-            "{}(stream_id: {}; flags: {}): {}"
+            "{}(stream_id={}, flags={}): {}"
         ).format(
             type(self).__name__,
             self.stream_id,
-            ", ".join(sorted(self.flags)) or "None",
+            repr(self.flags),
             self._body_repr(),
         )
 
@@ -350,7 +350,7 @@ class PriorityFrame(Priority, Frame):
     stream_association = _STREAM_ASSOC_HAS_STREAM
 
     def _body_repr(self):
-        return "exclusive: {}, depends_on: {}, stream_weight: {}".format(
+        return "exclusive={}, depends_on={}, stream_weight={}".format(
             self.exclusive,
             self.depends_on,
             self.stream_weight
@@ -394,7 +394,7 @@ class RstStreamFrame(Frame):
         self.error_code = error_code
 
     def _body_repr(self):
-        return "error_code: {}".format(
+        return "error_code={}".format(
             self.error_code,
         )
 
@@ -465,7 +465,7 @@ class SettingsFrame(Frame):
         self.settings = settings or {}
 
     def _body_repr(self):
-        return "settings: {}".format(
+        return "settings={}".format(
             self.settings,
         )
 
@@ -520,7 +520,7 @@ class PushPromiseFrame(Padding, Frame):
         self.data = data
 
     def _body_repr(self):
-        return "promised_stream_id: {}, data: {}".format(
+        return "promised_stream_id={}, data={}".format(
             self.promised_stream_id,
             _raw_data_repr(self.data),
         )
@@ -577,7 +577,7 @@ class PingFrame(Frame):
         self.opaque_data = opaque_data
 
     def _body_repr(self):
-        return "opaque_data: {}".format(
+        return "opaque_data={}".format(
             self.opaque_data,
         )
 
@@ -635,7 +635,7 @@ class GoAwayFrame(Frame):
         self.additional_data = additional_data
 
     def _body_repr(self):
-        return "last_stream_id: {}, error_code: {}, additional_data: {}".format(
+        return "last_stream_id={}, error_code={}, additional_data={}".format(
             self.last_stream_id,
             self.error_code,
             self.additional_data,
@@ -692,7 +692,7 @@ class WindowUpdateFrame(Frame):
         self.window_increment = window_increment
 
     def _body_repr(self):
-        return "window_increment: {}".format(
+        return "window_increment={}".format(
             self.window_increment,
         )
 
@@ -751,7 +751,7 @@ class HeadersFrame(Padding, Priority, Frame):
         self.data = data
 
     def _body_repr(self):
-        return "exclusive: {}, depends_on: {}, stream_weight: {}, data: {}".format(
+        return "exclusive={}, depends_on={}, stream_weight={}, data={}".format(
             self.exclusive,
             self.depends_on,
             self.stream_weight,
@@ -812,7 +812,7 @@ class ContinuationFrame(Frame):
         self.data = data
 
     def _body_repr(self):
-        return "data: {}".format(
+        return "data={}".format(
             _raw_data_repr(self.data),
         )
 
@@ -854,7 +854,7 @@ class AltSvcFrame(Frame):
         self.field = field
 
     def _body_repr(self):
-        return "origin: {}, field: {}".format(
+        return "origin={}, field={}".format(
             self.origin,
             self.field,
         )
@@ -903,7 +903,7 @@ class ExtensionFrame(Frame):
         self.body = body
 
     def _body_repr(self):
-        return "type: {}, flag_byte: {}, body: {}".format(
+        return "type={}, flag_byte={}, body={}".format(
             self.type,
             self.flag_byte,
             _raw_data_repr(self.body),
@@ -947,7 +947,7 @@ def _raw_data_repr(data):
     r = binascii.hexlify(data).decode('ascii')
     if len(r) > 20:
         r = r[:20] + "..."
-    return r
+    return "<hex:" + r + ">"
 
 
 _FRAME_CLASSES = [

--- a/test/test_flags.py
+++ b/test/test_flags.py
@@ -33,3 +33,11 @@ class TestFlags:
         flags.add("VALID_FLAG")
         with pytest.raises(ValueError):
             flags.add("INVALID_FLAG")
+
+    def test_repr(self):
+        flags = Flags([Flag("VALID_FLAG", 0x00), Flag("OTHER_FLAG", 0x01)])
+        assert repr(flags) == "[]"
+        flags.add("VALID_FLAG")
+        assert repr(flags) == "['VALID_FLAG']"
+        flags.add("OTHER_FLAG")
+        assert repr(flags) == "['OTHER_FLAG', 'VALID_FLAG']"

--- a/test/test_frames.py
+++ b/test/test_frames.py
@@ -89,25 +89,25 @@ class TestGeneralFrameBehaviour:
         f = Frame(0)
         monkeypatch.setattr(Frame, "serialize_body", lambda _: b"body")
         assert repr(f) == (
-            "Frame(stream_id: 0; flags: None): 626f6479"
+            "Frame(stream_id=0, flags=[]): <hex:626f6479>"
         )
 
         f.stream_id = 42
         f.flags = ["END_STREAM", "PADDED"]
         assert repr(f) == (
-            "Frame(stream_id: 42; flags: END_STREAM, PADDED): 626f6479"
+            "Frame(stream_id=42, flags=['END_STREAM', 'PADDED']): <hex:626f6479>"
         )
 
         monkeypatch.setattr(Frame, "serialize_body", lambda _: b"A"*25)
         assert repr(f) == (
-            "Frame(stream_id: 42; flags: END_STREAM, PADDED): {}...".format("41"*10)
+            "Frame(stream_id=42, flags=['END_STREAM', 'PADDED']): <hex:{}...>".format("41"*10)
         )
 
     def test_frame_explain(self, capsys):
         d = b'\x00\x00\x08\x00\x01\x00\x00\x00\x01testdata'
         Frame.explain(memoryview(d))
         captured = capsys.readouterr()
-        assert captured.out.strip() == "DataFrame(stream_id: 1; flags: END_STREAM): 7465737464617461"
+        assert captured.out.strip() == "DataFrame(stream_id=1, flags=['END_STREAM']): <hex:7465737464617461>"
 
     def test_cannot_parse_invalid_frame_header(self):
         with pytest.raises(InvalidFrameError):
@@ -122,7 +122,7 @@ class TestDataFrame:
 
     def test_repr(self):
         f = DataFrame(1, b"testdata")
-        assert repr(f).endswith("7465737464617461")
+        assert repr(f).endswith("<hex:7465737464617461>")
 
     def test_data_frame_has_correct_flags(self):
         f = DataFrame(1)
@@ -251,11 +251,11 @@ class TestPriorityFrame:
 
     def test_repr(self):
         f = PriorityFrame(1)
-        assert repr(f).endswith("exclusive: False, depends_on: 0, stream_weight: 0")
+        assert repr(f).endswith("exclusive=False, depends_on=0, stream_weight=0")
         f.exclusive = True
         f.depends_on = 0x04
         f.stream_weight = 64
-        assert repr(f).endswith("exclusive: True, depends_on: 4, stream_weight: 64")
+        assert repr(f).endswith("exclusive=True, depends_on=4, stream_weight=64")
 
     def test_priority_frame_has_no_flags(self):
         f = PriorityFrame(1)
@@ -306,9 +306,9 @@ class TestPriorityFrame:
 class TestRstStreamFrame:
     def test_repr(self):
         f = RstStreamFrame(1)
-        assert repr(f).endswith("error_code: 0")
+        assert repr(f).endswith("error_code=0")
         f.error_code = 420
-        assert repr(f).endswith("error_code: 420")
+        assert repr(f).endswith("error_code=420")
 
     def test_rst_stream_frame_has_no_flags(self):
         f = RstStreamFrame(1)
@@ -366,9 +366,9 @@ class TestSettingsFrame:
 
     def test_repr(self):
         f = SettingsFrame()
-        assert repr(f).endswith("settings: {}")
+        assert repr(f).endswith("settings={}")
         f.settings[SettingsFrame.MAX_FRAME_SIZE] = 16384
-        assert repr(f).endswith("settings: {5: 16384}")
+        assert repr(f).endswith("settings={5: 16384}")
 
     def test_settings_frame_has_only_one_flag(self):
         f = SettingsFrame()
@@ -431,10 +431,10 @@ class TestSettingsFrame:
 class TestPushPromiseFrame:
     def test_repr(self):
         f = PushPromiseFrame(1)
-        assert repr(f).endswith("promised_stream_id: 0, data: None")
+        assert repr(f).endswith("promised_stream_id=0, data=None")
         f.promised_stream_id = 4
         f.data = b"testdata"
-        assert repr(f).endswith("promised_stream_id: 4, data: 7465737464617461")
+        assert repr(f).endswith("promised_stream_id=4, data=<hex:7465737464617461>")
 
     def test_push_promise_frame_flags(self):
         f = PushPromiseFrame(1)
@@ -523,9 +523,9 @@ class TestPushPromiseFrame:
 class TestPingFrame:
     def test_repr(self):
         f = PingFrame()
-        assert repr(f).endswith("opaque_data: b''")
+        assert repr(f).endswith("opaque_data=b''")
         f.opaque_data = b'hello'
-        assert repr(f).endswith("opaque_data: b'hello'")
+        assert repr(f).endswith("opaque_data=b'hello'")
 
     def test_ping_frame_has_only_one_flag(self):
         f = PingFrame()
@@ -581,11 +581,11 @@ class TestPingFrame:
 class TestGoAwayFrame:
     def test_repr(self):
         f = GoAwayFrame()
-        assert repr(f).endswith("last_stream_id: 0, error_code: 0, additional_data: b''")
+        assert repr(f).endswith("last_stream_id=0, error_code=0, additional_data=b''")
         f.last_stream_id = 64
         f.error_code = 32
         f.additional_data = b'hello'
-        assert repr(f).endswith("last_stream_id: 64, error_code: 32, additional_data: b'hello'")
+        assert repr(f).endswith("last_stream_id=64, error_code=32, additional_data=b'hello'")
 
     def test_go_away_has_no_flags(self):
         f = GoAwayFrame()
@@ -652,10 +652,10 @@ class TestGoAwayFrame:
 class TestWindowUpdateFrame:
     def test_repr(self):
         f = WindowUpdateFrame(0)
-        assert repr(f).endswith("window_increment: 0")
+        assert repr(f).endswith("window_increment=0")
         f.stream_id = 1
         f.window_increment = 512
-        assert repr(f).endswith("window_increment: 512")
+        assert repr(f).endswith("window_increment=512")
 
     def test_window_update_has_no_flags(self):
         f = WindowUpdateFrame(0)
@@ -699,12 +699,12 @@ class TestWindowUpdateFrame:
 class TestHeadersFrame:
     def test_repr(self):
         f = HeadersFrame(1)
-        assert repr(f).endswith("exclusive: False, depends_on: 0, stream_weight: 0, data: None")
+        assert repr(f).endswith("exclusive=False, depends_on=0, stream_weight=0, data=None")
         f.data = b'hello'
         f.exclusive = True
         f.depends_on = 42
         f.stream_weight = 64
-        assert repr(f).endswith("exclusive: True, depends_on: 42, stream_weight: 64, data: 68656c6c6f")
+        assert repr(f).endswith("exclusive=True, depends_on=42, stream_weight=64, data=<hex:68656c6c6f>")
 
     def test_headers_frame_flags(self):
         f = HeadersFrame(1)
@@ -790,9 +790,9 @@ class TestHeadersFrame:
 class TestContinuationFrame:
     def test_repr(self):
         f = ContinuationFrame(1)
-        assert repr(f).endswith("data: None")
+        assert repr(f).endswith("data=None")
         f.data = b'hello'
-        assert repr(f).endswith("data: 68656c6c6f")
+        assert repr(f).endswith("data=<hex:68656c6c6f>")
 
     def test_continuation_frame_flags(self):
         f = ContinuationFrame(1)
@@ -852,11 +852,11 @@ class TestAltSvcFrame:
 
     def test_repr(self):
         f = AltSvcFrame(0)
-        assert repr(f).endswith("origin: b'', field: b''")
+        assert repr(f).endswith("origin=b'', field=b''")
         f.field = b'h2="alt.example.com:8000", h2=":443"'
-        assert repr(f).endswith("origin: b'', field: b'h2=\"alt.example.com:8000\", h2=\":443\"'")
+        assert repr(f).endswith("origin=b'', field=b'h2=\"alt.example.com:8000\", h2=\":443\"'")
         f.origin = b'example.com'
-        assert repr(f).endswith("origin: b'example.com', field: b'h2=\"alt.example.com:8000\", h2=\":443\"'")
+        assert repr(f).endswith("origin=b'example.com', field=b'h2=\"alt.example.com:8000\", h2=\":443\"'")
 
     def test_altsvc_frame_flags(self):
         f = AltSvcFrame(0)
@@ -927,4 +927,4 @@ class TestAltSvcFrame:
 class TestExtensionFrame:
     def test_repr(self):
         f = ExtensionFrame(0xFF, 1, 42, b'hello')
-        assert repr(f).endswith("type: 255, flag_byte: 42, body: 68656c6c6f")
+        assert repr(f).endswith("type=255, flag_byte=42, body=<hex:68656c6c6f>")


### PR DESCRIPTION
- Improve `repr()` output for all frame classes by also showing a meaningful body/payload/data.
- Introduce `Frame.explain(data)` for quick introspection of raw data by parsing a single frame from a given bytes string.