### PR TITLE
Fix setting identifier truncation in SettingsFrame.serialize_body

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,10 @@ Release History
 dev
 ---
 
+**API Changes (Backward Compatible)**
+
+- Setting Identifier are now correctly serialized as 16-bit values, instead of 8-bit.
+
 **API Changes (Backward Incompatible)**
 
 -

--- a/src/hyperframe/frame.py
+++ b/src/hyperframe/frame.py
@@ -457,8 +457,11 @@ class SettingsFrame(Frame):
         return f"settings={self.settings}"
 
     def serialize_body(self) -> bytes:
-        return b"".join([_STRUCT_HL.pack(setting & 0xFFFF, value)
-                         for setting, value in self.settings.items()])
+        return b"".join([_STRUCT_HL.pack(
+            setting_identifier & 0xFFFF, # Settings identifiers are 16 bits, mask them appropriately, RFC 9113, Section 6.5.1
+            setting_value & 0xFFFFFFFF,  # Settings values are 32 bits, mask them appropriately, RFC 9113, Section 6.5.1
+        )
+                         for setting_identifier, setting_value in self.settings.items()])
 
     def parse_body(self, data: memoryview) -> None:
         if "ACK" in self.flags and len(data) > 0:

--- a/src/hyperframe/frame.py
+++ b/src/hyperframe/frame.py
@@ -457,7 +457,7 @@ class SettingsFrame(Frame):
         return f"settings={self.settings}"
 
     def serialize_body(self) -> bytes:
-        return b"".join([_STRUCT_HL.pack(setting & 0xFF, value)
+        return b"".join([_STRUCT_HL.pack(setting & 0xFFFF, value)
                          for setting, value in self.settings.items()])
 
     def parse_body(self, data: memoryview) -> None:

--- a/tests/test_frames.py
+++ b/tests/test_frames.py
@@ -426,6 +426,29 @@ class TestSettingsFrame:
         with pytest.raises(InvalidDataError):
             decode_frame(self.serialized[:-2])
 
+    def test_settings_frame_with_large_setting_ids(self):
+        f = SettingsFrame()
+        f.settings[0xFFFE] = 12345
+        f.settings[0xFFFF] = 54321
+
+        s = f.serialize()
+        new_f = decode_frame(s)
+
+        assert new_f.settings[0xFFFE] == 12345
+        assert new_f.settings[0xFFFF] == 54321
+
+    def test_settings_frame_serializes_with_large_setting_ids(self):
+        f = SettingsFrame()
+        f.settings[0xFFFE] = 12345
+        f.settings[0xFFFF] = 54321
+
+        s = f.serialize()
+        assert s == (
+            b'\x00\x00\x0C\x04\x00\x00\x00\x00\x00' +  # Frame header
+            b'\xFF\xFE\x00\x00\x30\x39' +              # Setting ID 0xFFFE
+            b'\xFF\xFF\x00\x00\xd4\x31'                # Setting ID 0xFFFF
+        )
+
 
 class TestPushPromiseFrame:
     def test_repr(self):


### PR DESCRIPTION
`SettingsFrame.serialize_body` masks the setting identifier with `& 0xFF`, which truncates it to 8 bits. The identifier field in HTTP/2 SETTINGS frames is 16 bits wide (RFC 9113, Section 6.5.1), and `_STRUCT_HL` already packs it as an unsigned short (`H`, 16 bits).

Standard settings (0x01–0x08) fit in a single byte, so this has gone unnoticed. But any setting identifier above 255 — for example GREASE values from RFC 8701 (`0x0a0a`, `0x1a1a`, …) or future extensions — gets silently corrupted:

```python
>>> _STRUCT_HL.pack(0x0a0a & 0xFF, 1)   # current: packs 0x000a
>>> _STRUCT_HL.pack(0x0a0a & 0xFFFF, 1)  # fixed: packs 0x0a0a
```

`parse_body` already reads the full 16-bit identifier correctly (`_STRUCT_HL.unpack`), so this also breaks the serialize→parse round-trip for those values.

This changes the mask from `0xFF` to `0xFFFF`.
