### PR TITLE
Mask reserved bit when parsing GoAway and WindowUpdate frames

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,9 @@ dev
 **API Changes (Backward Compatible)**
 
 - Setting Identifier are now correctly serialized as 16-bit values, instead of 8-bit.
+- GoAwayFrame and WindowUpdateFrame now correctly mask off the reserved bit during
+  parsing and serialization of stream IDs and window increments, as per RFC 9113,
+  Sections 6.8 and 6.9.
 
 **API Changes (Backward Incompatible)**
 

--- a/src/hyperframe/frame.py
+++ b/src/hyperframe/frame.py
@@ -132,7 +132,7 @@ class Frame:
         length = (fields[0] << 8) + fields[1]
         typ_e = fields[2]
         flags = fields[3]
-        stream_id = fields[4] & 0x7FFFFFFF
+        stream_id = fields[4] & 0x7FFFFFFF # mask off the reserved bit, RFC 9113, Section 4.1
 
         try:
             frame = FRAMES[typ_e](stream_id)
@@ -172,7 +172,7 @@ class Frame:
             self.body_len & 0xFF,
             self.type,
             flags,
-            self.stream_id & 0x7FFFFFFF,  # Stream ID is 32 bits.
+            self.stream_id & 0x7FFFFFFF,  # mask off the reserved bit, RFC 9113, Section 4.1
         )
 
         return header + body
@@ -271,7 +271,7 @@ class Priority:
             raise InvalidFrameError(msg) from err
 
         self.exclusive = bool(self.depends_on >> 31)
-        self.depends_on &= 0x7FFFFFFF
+        self.depends_on &= 0x7FFFFFFF  # mask off the exclusive bit, RFC 9113, Section 6.3
         return 5
 
 
@@ -623,7 +623,7 @@ class GoAwayFrame(Frame):
 
     def serialize_body(self) -> bytes:
         data = _STRUCT_LL.pack(
-            self.last_stream_id & 0x7FFFFFFF,
+            self.last_stream_id & 0x7FFFFFFF, # mask off the reserved bit, RFC 9113, Section 6.8
             self.error_code,
         )
         data += self.additional_data
@@ -639,6 +639,7 @@ class GoAwayFrame(Frame):
             msg = "Invalid GOAWAY body."
             raise InvalidFrameError(msg) from err
 
+        # mask off the reserved bit, RFC 9113, Section 6.8
         self.last_stream_id = self.last_stream_id & 0x7FFFFFFF
         self.body_len = len(data)
 
@@ -678,7 +679,9 @@ class WindowUpdateFrame(Frame):
         return f"window_increment={self.window_increment}"
 
     def serialize_body(self) -> bytes:
-        return _STRUCT_L.pack(self.window_increment & 0x7FFFFFFF)
+        return _STRUCT_L.pack(
+            self.window_increment & 0x7FFFFFFF, # mask off the reserved bit, RFC 9113, Section 6.9
+        )
 
     def parse_body(self, data: memoryview) -> None:
         if len(data) > 4:
@@ -691,6 +694,7 @@ class WindowUpdateFrame(Frame):
             msg = "Invalid WINDOW_UPDATE body"
             raise InvalidFrameError(msg) from err
 
+        # mask off the reserved bit, RFC 9113, Section 6.9
         self.window_increment = self.window_increment & 0x7FFFFFFF
 
         if not 1 <= self.window_increment <= 2**31-1:
@@ -910,7 +914,7 @@ class ExtensionFrame(Frame):
             self.body_len & 0xFF,
             self.type,
             flags,
-            self.stream_id & 0x7FFFFFFF,  # Stream ID is 32 bits.
+            self.stream_id & 0x7FFFFFFF,  # mask off the reserved bit, RFC 9113, Section 4.1
         )
 
         return header + self.body

--- a/src/hyperframe/frame.py
+++ b/src/hyperframe/frame.py
@@ -639,6 +639,7 @@ class GoAwayFrame(Frame):
             msg = "Invalid GOAWAY body."
             raise InvalidFrameError(msg) from err
 
+        self.last_stream_id = self.last_stream_id & 0x7FFFFFFF
         self.body_len = len(data)
 
         if len(data) > 8:
@@ -689,6 +690,8 @@ class WindowUpdateFrame(Frame):
         except struct.error as err:
             msg = "Invalid WINDOW_UPDATE body"
             raise InvalidFrameError(msg) from err
+
+        self.window_increment = self.window_increment & 0x7FFFFFFF
 
         if not 1 <= self.window_increment <= 2**31-1:
             msg = "WINDOW_UPDATE increment must be between 1 to 2^31-1"

--- a/tests/test_frames.py
+++ b/tests/test_frames.py
@@ -670,6 +670,35 @@ class TestGoAwayFrame:
         with pytest.raises(InvalidFrameError):
             decode_frame(s)
 
+    def test_goaway_frame_with_reserved_bit_set_parses_properly(self):
+        s = (
+            b'\x00\x00\x0D\x07\x00\x00\x00\x00\x00' +  # Frame header
+            b'\x80\x00\x00\x40' +                      # Last Stream ID with reserved bit set
+            b'\x00\x00\x00\x20' +                      # Error Code
+            b'hello'                                   # Additional data
+        )
+        f = decode_frame(s)
+
+        assert isinstance(f, GoAwayFrame)
+        assert f.flags == set()
+        assert f.additional_data == b'hello'
+        assert f.body_len == 13
+        assert f.last_stream_id == 64
+
+    def test_goaway_frame_with_reserved_bit_set_serializes_properly(self):
+        f = GoAwayFrame()
+        f.last_stream_id = 64
+        f.error_code = 32
+        f.additional_data = b'hello'
+
+        s = f.serialize()
+        assert s == (
+            b'\x00\x00\x0D\x07\x00\x00\x00\x00\x00' +  # Frame header
+            b'\x00\x00\x00\x40' +                      # Last Stream ID
+            b'\x00\x00\x00\x20' +                      # Error Code
+            b'hello'                                   # Additional data
+        )
+
 
 class TestWindowUpdateFrame:
     def test_repr(self):
@@ -716,6 +745,22 @@ class TestWindowUpdateFrame:
 
         with pytest.raises(InvalidDataError):
             decode_frame(WindowUpdateFrame(2**31).serialize())
+
+    def test_window_update_frame_with_reserved_bit_set_parses_properly(self):
+        s = b'\x00\x00\x04\x08\x00\x00\x00\x00\x80\x00\x00\x02\x00'
+        f = decode_frame(s)
+
+        assert isinstance(f, WindowUpdateFrame)
+        assert f.flags == set()
+        assert f.window_increment == 512
+        assert f.body_len == 4
+
+    def test_window_update_frame_with_reserved_bit_set_serializes_properly(self):
+        f = WindowUpdateFrame(0)
+        f.window_increment = 512
+
+        s = f.serialize()
+        assert s == b'\x00\x00\x04\x08\x00\x00\x00\x00\x00\x00\x00\x02\x00'
 
 
 class TestHeadersFrame:


### PR DESCRIPTION
`GoAwayFrame.parse_body` reads `last_stream_id` as a raw 32-bit value without masking out the reserved top bit. `serialize_body` already applies `& 0x7FFFFFFF` (line 636), but the parse path doesn't, so if a peer sets the reserved bit, `last_stream_id` ends up as a value >= 2^31 instead of the actual stream ID.

Same issue in `WindowUpdateFrame.parse_body` — the reserved bit isn't stripped before the range check, so a WINDOW_UPDATE with the reserved bit set is rejected with `InvalidDataError` even though RFC 9113 Section 6.9 says the bit "MUST be ignored when receiving."

The rest of the codebase already handles this correctly:
- `Frame.parse_frame_header` masks `stream_id & 0x7FFFFFFF`
- `Priority.parse_priority_data` masks `depends_on & 0x7FFFFFFF`

This adds the same mask to both `GoAwayFrame.parse_body` and `WindowUpdateFrame.parse_body`.
